### PR TITLE
확인 기능만 존재하는 커스텀 다이어로그 구현

### DIFF
--- a/app/src/main/java/com/dogdduddy/jmt/utils/extentions.kt
+++ b/app/src/main/java/com/dogdduddy/jmt/utils/extentions.kt
@@ -1,0 +1,34 @@
+package com.dogdduddy.jmt.utils
+
+import android.os.Build
+import android.util.DisplayMetrics
+import androidx.fragment.app.Fragment
+
+val Fragment.deviceMetrics
+    get() = run {
+
+        val displayMetrics = DisplayMetrics()
+
+        // target version above 30
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+
+            val windowManager = requireActivity().windowManager
+
+            // target version above 31
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+
+                val metrics = windowManager.currentWindowMetrics
+                metrics.bounds.also { bounds ->
+                    displayMetrics.widthPixels = bounds.width()
+                    displayMetrics.heightPixels = bounds.height()
+                }
+            } else {
+                val display = requireActivity().display
+                display?.getRealMetrics(displayMetrics)
+            }
+
+        } else {
+            requireActivity().windowManager.defaultDisplay?.getMetrics(displayMetrics)
+        }
+        displayMetrics
+    }

--- a/app/src/main/java/com/dogdduddy/jmt/view/JmtConfirmDialog.kt
+++ b/app/src/main/java/com/dogdduddy/jmt/view/JmtConfirmDialog.kt
@@ -1,0 +1,76 @@
+package com.dogdduddy.jmt.view
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.dogdduddy.jmt.R
+import com.dogdduddy.jmt.databinding.JmtConfirmDialogBinding
+import com.dogdduddy.jmt.utils.deviceMetrics
+
+class JmtConfirmDialog(private val context: Context) : DialogFragment() {
+
+    private var _binding: JmtConfirmDialogBinding? = null
+    private val binding
+        get() = _binding ?: run {
+            _binding = LayoutInflater.from(context).let {
+                JmtConfirmDialogBinding.inflate(it)
+            }
+            _binding!!
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        dialog?.window?.setBackgroundDrawableResource(R.drawable.jmt_confirm_dialog_background)
+        isCancelable = false
+
+        binding.confirmButton.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        val displayMetrics = deviceMetrics
+
+        val displayWidth = displayMetrics.widthPixels
+        val displayHeight = displayMetrics.heightPixels
+
+        val dialogWindowWidth = (displayWidth * 0.9f).toInt()
+        val dialogWindowHeight = (displayHeight * 0.25f).toInt()
+
+        dialog?.window?.setLayout(dialogWindowWidth, dialogWindowHeight)
+    }
+
+    fun setTitle(title: String): JmtConfirmDialog {
+        binding.titleText.text = title
+        return this
+    }
+
+    fun setContent(content: String): JmtConfirmDialog {
+        binding.contentText.text = content
+        return this
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG = "JmtConfirmDialog"
+    }
+}

--- a/app/src/main/res/drawable/jmt_confirm_dialog_background.xml
+++ b/app/src/main/res/drawable/jmt_confirm_dialog_background.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="20dp" />
+</shape>

--- a/app/src/main/res/drawable/jmt_confirm_dialog_button_background.xml
+++ b/app/src/main/res/drawable/jmt_confirm_dialog_button_background.xml
@@ -1,0 +1,9 @@
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/main800">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/main600" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/jmt_confirm_dialog.xml
+++ b/app/src/main/res/layout/jmt_confirm_dialog.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/title_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="74.5dp"
+        android:layout_marginTop="24dp"
+        android:gravity="center_horizontal"
+        android:textSize="18sp"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="회원가입을 할 수 없습니다"/>
+
+    <TextView
+        android:id="@+id/content_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center_horizontal"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/title_text"
+        tools:text="와이파이 연결상태를\n 다시 확인해주세요."/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/confirm_button"
+        android:text="@string/confirm"
+        android:textSize="20sp"
+        android:layout_width="0dp"
+        android:layout_height="62dp"
+        android:layout_marginHorizontal="27.5dp"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/jmt_confirm_dialog_button_background"
+        app:backgroundTint="#20BC2F"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/content_text"
+        tools:text="확인"/>
+    <Space
+        android:layout_width="wrap_content"
+        android:layout_height="24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/confirm_button"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <color name="main600">#20BC2F</color>
+    <color name="main800">#116419</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">JMT</string>
     <string name="my_web_client_id">846233671186-4vknaa3i38pfkeourp2q37lolncdbmhl.apps.googleusercontent.com</string>
+    <string name="confirm">확인</string>
 </resources>


### PR DESCRIPTION
## 개요
- 확인 버튼만 존재하는 custom Confirm Dialog 추가
  - 일반적으로 경고를 알려주는 용도로만 쓰이는 Modal dialog

## 사용 방법
<img width="553" alt="Screenshot 2023-03-17 at 12 35 11 AM" src="https://user-images.githubusercontent.com/90144041/225674519-49b8006b-7c37-4deb-80a7-945040215fbb.png">
- 빌더 패턴을 적용하여 set~~ 메서드로 제목, 경고 내용을 지정해줄 수 있음.

## 동작 모습
![jmt_dialog](https://user-images.githubusercontent.com/90144041/225674753-7142d774-ce4e-468b-bfaf-83df0dcd4b5a.gif)


## 비고
- 정확한 뷰 크기 반영이 잘 안되어서 우선은 임의로 화면 크기 비례로 다이어로그 크기를 만들었음. -> 추후 수정 필요
- 폰트가 아직 확정은 아니라서 크기만 하드 코딩해놓은 상태
 