### PR TITLE
회원가입 페이지 뷰 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:theme="@style/Theme.JMT"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="org.gdsc.presentation.view.LoginActivity"
+            android:name="org.gdsc.presentation.view.TestActivity"
             android:exported="true">
 
             <intent-filter>

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.3.15'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3"
     }
 }
 plugins {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
     id 'com.android.library'
+    id 'androidx.navigation.safeargs.kotlin'
 }
 
 Properties properties = new Properties()
@@ -89,4 +90,16 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+
+    def nav_version = "2.5.3"
+
+    // Kotlin
+    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
+
+    // Feature module Support
+    implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"
+
+    // Testing Navigation
+    androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
 
     <application>
         <activity
+            android:name="org.gdsc.presentation.login.LoginActivity"
+            android:exported="false" />
+        <activity
             android:name="org.gdsc.presentation.view.WebViewActivity"
             android:exported="false" />
         <activity

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <application>
         <activity
             android:name="org.gdsc.presentation.login.LoginActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false" />
         <activity
             android:name="org.gdsc.presentation.view.WebViewActivity"

--- a/presentation/src/main/java/org/gdsc/presentation/login/LoginActivity.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/LoginActivity.kt
@@ -1,0 +1,18 @@
+package org.gdsc.presentation.login
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import org.gdsc.presentation.databinding.ActivityLoginBinding
+
+class LoginActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityLoginBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+
+}

--- a/presentation/src/main/java/org/gdsc/presentation/login/LoginFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/LoginFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.navigation.fragment.findNavController
 import org.gdsc.presentation.R
 import org.gdsc.presentation.databinding.FragmentLoginBinding
 
@@ -36,13 +37,15 @@ class LoginFragment : Fragment() {
             child?.text = context.getString(R.string.continue_with_google)
 
             setOnClickListener {
-
+                val action = LoginFragmentDirections.actionLoginFragmentToSignUpNicknameFragment()
+                findNavController().navigate(action)
             }
         }
 
         // TODO: 가입 여부 확인 후 가입되어있으면 메인 화면으로 그렇지 않으면 가입 화면으로 이동
         binding.appleLoginBtn.setOnClickListener {
-
+            val action = LoginFragmentDirections.actionLoginFragmentToSignUpNicknameFragment()
+            findNavController().navigate(action)
         }
     }
 

--- a/presentation/src/main/java/org/gdsc/presentation/login/LoginFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/LoginFragment.kt
@@ -1,0 +1,54 @@
+package org.gdsc.presentation.login
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import org.gdsc.presentation.R
+import org.gdsc.presentation.databinding.FragmentLoginBinding
+
+class LoginFragment : Fragment() {
+
+    private var _binding: FragmentLoginBinding? = null
+    private val binding
+        get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setLoginButton()
+    }
+
+    private fun setLoginButton() {
+        // TODO: 가입 여부 확인 후 가입되어있으면 메인 화면으로 그렇지 않으면 가입 화면으로 이동
+        binding.googleLoginBtn.apply {
+
+            val child = getChildAt(0) as? TextView
+            child?.text = context.getString(R.string.continue_with_google)
+
+            setOnClickListener {
+
+            }
+        }
+
+        // TODO: 가입 여부 확인 후 가입되어있으면 메인 화면으로 그렇지 않으면 가입 화면으로 이동
+        binding.appleLoginBtn.setOnClickListener {
+
+        }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+
+}

--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
@@ -29,6 +29,10 @@ class SignUpCompleteFragment : Fragment() {
 
         binding.nicknameText.text = args.nickname
 
+        binding.profileImageAddButton.setOnClickListener {
+            // TODO: 갤러리에서 이미지 pick
+        }
+
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
@@ -5,37 +5,35 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.fragment.findNavController
-import org.gdsc.presentation.databinding.FragmentSignUpNicknameBinding
+import androidx.navigation.fragment.navArgs
+import org.gdsc.presentation.databinding.FragmentSignUpCompleteBinding
 
-class SignUpNicknameFragment : Fragment() {
+class SignUpCompleteFragment : Fragment() {
 
-    private var _binding: FragmentSignUpNicknameBinding? = null
+    private var _binding: FragmentSignUpCompleteBinding? = null
     private val binding
         get() = requireNotNull(_binding)
+
+    private val args: SignUpCompleteFragmentArgs by navArgs()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentSignUpNicknameBinding.inflate(inflater, container, false)
+        _binding = FragmentSignUpCompleteBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setNextButton()
-    }
 
-    private fun setNextButton() {
-        binding.nextBtn.setOnClickListener {
-            val action = SignUpNicknameFragmentDirections.actionSignUpNicknameFragmentToSignUpCompleteFragment(binding.nicknameEditText.text)
-            findNavController().navigate(action)
-        }
+        binding.nicknameText.text = args.nickname
+
     }
 
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
     }
+
 }

--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpNicknameFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpNicknameFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import org.gdsc.presentation.databinding.FragmentSignUpNicknameBinding
+import org.gdsc.presentation.utils.hideKeyBoard
 
 class SignUpNicknameFragment : Fragment() {
 
@@ -25,6 +26,13 @@ class SignUpNicknameFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setNextButton()
+        setHideKeyboard()
+    }
+
+    private fun setHideKeyboard() {
+        binding.root.setOnClickListener {
+            hideKeyBoard(requireActivity())
+        }
     }
 
     private fun setNextButton() {

--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpNicknameFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpNicknameFragment.kt
@@ -1,0 +1,39 @@
+package org.gdsc.presentation.login
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.gdsc.presentation.databinding.FragmentSignUpNicknameBinding
+
+class SignUpNicknameFragment : Fragment() {
+
+    private var _binding: FragmentSignUpNicknameBinding? = null
+    private val binding
+        get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSignUpNicknameBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setNextButton()
+    }
+
+    private fun setNextButton() {
+        binding.nextBtn.setOnClickListener {
+
+        }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/presentation/src/main/java/org/gdsc/presentation/utils/extentions.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/utils/extentions.kt
@@ -1,7 +1,10 @@
 package org.gdsc.presentation.utils
 
+import android.app.Activity
+import android.content.Context
 import android.os.Build
 import android.util.DisplayMetrics
+import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 
 val Fragment.deviceMetrics
@@ -32,3 +35,8 @@ val Fragment.deviceMetrics
         }
         displayMetrics
     }
+
+fun Fragment.hideKeyBoard(activity: Activity) {
+    val inputMethodManager = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    inputMethodManager.hideSoftInputFromWindow(activity.currentFocus?.windowToken, 0)
+}

--- a/presentation/src/main/java/org/gdsc/presentation/view/JmtEditText.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/JmtEditText.kt
@@ -15,6 +15,7 @@ class JmtEditText(context: Context, attrs: AttributeSet) : ConstraintLayout(cont
 
     private val binding = JmtEditTextBinding.inflate(LayoutInflater.from(context), this, true)
 
+    val text get() = binding.nicknameEditText.text.toString()
     init {
         removeAllViews()
         addView(binding.root)

--- a/presentation/src/main/java/org/gdsc/presentation/view/TestActivity.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/TestActivity.kt
@@ -10,22 +10,22 @@ import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
-import org.gdsc.presentation.viewmodel.LoginViewModel
+import org.gdsc.presentation.viewmodel.TestViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
-import org.gdsc.presentation.databinding.ActivityLoginBinding
+import org.gdsc.presentation.databinding.ActivityTestBinding
 
 @AndroidEntryPoint
-class LoginActivity : AppCompatActivity() {
-    private lateinit var binding: ActivityLoginBinding
+class TestActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityTestBinding
 
-    private val viewModel: LoginViewModel by viewModels()
+    private val viewModel: TestViewModel by viewModels()
 
     private val TAG = "LoginTest"
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityLoginBinding.inflate(layoutInflater)
+        binding = ActivityTestBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         binding.appleLoginBtn.setOnClickListener {
@@ -35,7 +35,7 @@ class LoginActivity : AppCompatActivity() {
         binding.googleLoginBtn.setOnClickListener {
             lifecycleScope.launch(CoroutineExceptionHandler { _, throwable -> throwable.printStackTrace() }) {
                 startForResult.launch(
-                    IntentSenderRequest.Builder(viewModel.googleLogin(this@LoginActivity)).build()
+                    IntentSenderRequest.Builder(viewModel.googleLogin(this@TestActivity)).build()
                 )
             }
         }

--- a/presentation/src/main/java/org/gdsc/presentation/viewmodel/TestViewModel.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/viewmodel/TestViewModel.kt
@@ -18,7 +18,7 @@ import org.gdsc.presentation.R
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginViewModel @Inject constructor(
+class TestViewModel @Inject constructor(
     private val postGoogleTokenUseCase: PostGoogleTokenUseCase,
     private val postAppleTokenUseCase: PostAppleTokenUseCase
 ) : ViewModel() {
@@ -83,7 +83,7 @@ class LoginViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "LoginViewModel"
+        private const val TAG = "TestViewModel"
     }
 
 }

--- a/presentation/src/main/res/drawable/base_profile_image.xml
+++ b/presentation/src/main/res/drawable/base_profile_image.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="154dp"
+    android:height="154dp"
+    android:viewportWidth="154"
+    android:viewportHeight="154">
+  <path
+      android:pathData="M77,77m-77,0a77,77 0,1 1,154 0a77,77 0,1 1,-154 0"
+      android:fillColor="#F1F3F4"/>
+  <group>
+    <clip-path
+        android:pathData="M78,93C94.57,93 108,79.57 108,63C108,46.43 94.57,33 78,33C61.43,33 48,46.43 48,63C48,79.57 61.43,93 78,93ZM99,100.5H95.09C89.88,102.89 84.09,104.25 78,104.25C71.91,104.25 66.14,102.89 60.91,100.5H57C39.61,100.5 25.5,114.61 25.5,132V141.75C25.5,147.96 30.54,153 36.75,153H119.25C125.46,153 130.5,147.96 130.5,141.75V132C130.5,114.61 116.39,100.5 99,100.5Z"/>
+    <path
+        android:pathData="M77,77m-77,0a77,77 0,1 1,154 0a77,77 0,1 1,-154 0"
+        android:fillColor="#D4DADE"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/drawable/profile_icon.xml
+++ b/presentation/src/main/res/drawable/profile_icon.xml
@@ -1,0 +1,5 @@
+<vector android:height="154dp" android:tint="#D4DADE"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="154dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,6c1.93,0 3.5,1.57 3.5,3.5S13.93,13 12,13s-3.5,-1.57 -3.5,-3.5S10.07,6 12,6zM12,20c-2.03,0 -4.43,-0.82 -6.14,-2.88C7.55,15.8 9.68,15 12,15s4.45,0.8 6.14,2.12C16.43,19.18 14.03,20 12,20z"/>
+</vector>

--- a/presentation/src/main/res/drawable/profile_icon.xml
+++ b/presentation/src/main/res/drawable/profile_icon.xml
@@ -1,5 +1,0 @@
-<vector android:height="154dp" android:tint="#D4DADE"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="154dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,6c1.93,0 3.5,1.57 3.5,3.5S13.93,13 12,13s-3.5,-1.57 -3.5,-3.5S10.07,6 12,6zM12,20c-2.03,0 -4.43,-0.82 -6.14,-2.88C7.55,15.8 9.68,15 12,15s4.45,0.8 6.14,2.12C16.43,19.18 14.03,20 12,20z"/>
-</vector>

--- a/presentation/src/main/res/drawable/profile_image_add_button.xml
+++ b/presentation/src/main/res/drawable/profile_image_add_button.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M20,20m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0"
+      android:fillColor="#ffffff"/>
+  <group>
+    <clip-path
+        android:pathData="M2,2h36v36h-36z"/>
+    <path
+        android:pathData="M20,20m-17.25,0a17.25,17.25 0,1 1,34.5 0a17.25,17.25 0,1 1,-34.5 0"
+        android:fillColor="#20BC2F"/>
+    <path
+        android:pathData="M30.349,17.412H22.587V9.649C22.587,8.697 21.815,7.924 20.862,7.924H19.137C18.184,7.924 17.412,8.697 17.412,9.649V17.412H9.649C8.697,17.412 7.924,18.184 7.924,19.137V20.862C7.924,21.814 8.697,22.587 9.649,22.587H17.412V30.349C17.412,31.302 18.184,32.074 19.137,32.074H20.862C21.815,32.074 22.587,31.302 22.587,30.349V22.587H30.349C31.302,22.587 32.074,21.814 32.074,20.862V19.137C32.074,18.184 31.302,17.412 30.349,17.412Z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/layout/activity_login.xml
+++ b/presentation/src/main/res/layout/activity_login.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment_container"
+        android:layout_height="0dp"
+        android:layout_width="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/login_nav_graph">
+
+    </androidx.fragment.app.FragmentContainerView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/activity_test.xml
+++ b/presentation/src/main/res/layout/activity_test.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="org.gdsc.presentation.view.LoginActivity">
+    tools:context="org.gdsc.presentation.view.TestActivity">
     <Button
         android:id="@+id/appleLoginBtn"
         android:layout_width="wrap_content"

--- a/presentation/src/main/res/layout/fragment_login.xml
+++ b/presentation/src/main/res/layout/fragment_login.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginHorizontal="20dp"
+    tools:context=".login.LoginFragment">
+
+    <com.google.android.gms.common.SignInButton
+        android:id="@+id/google_login_btn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/apple_login_btn"
+        android:layout_marginBottom="24dp"/>
+
+    <TextView
+        android:id="@+id/apple_login_btn"
+        android:text="@string/continue_with_apple"
+        android:textSize="14sp"
+        android:textColor="@color/grayscale600"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginBottom="56dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_sign_up_complete.xml
+++ b/presentation/src/main/res/layout/fragment_sign_up_complete.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginHorizontal="20dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".login.SignUpCompleteFragment">
+
+    <TextView
+        android:id="@+id/congratulatory_text"
+        android:text="@string/congratulation_sign_up"
+        android:textAppearance="@style/title_medium_bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="56dp"/>
+
+    <TextView
+        android:id="@+id/ask_profile_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/text_large_medium"
+        android:text="@string/suggest_set_profile_image"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/congratulatory_text"
+        android:layout_marginTop="8dp"/>
+    
+    <ImageView
+        android:id="@+id/profile_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ask_profile_text"
+        android:src="@drawable/profile_icon"
+        android:layout_marginTop="24dp"
+        android:contentDescription="@string/content_description_profile_image" />
+
+    <TextView
+        android:id="@+id/nickname_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/title_small_bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/profile_image"
+        android:layout_marginTop="12dp"
+        tools:text="닉네임"/>
+
+    <TextView
+        android:id="@+id/profile_setting_alert_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/alert_setting_profile_image"
+        android:textAppearance="@style/text_medium_medium"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/next_btn"
+        android:layout_marginBottom="36dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/next_btn"
+        android:layout_width="0dp"
+        android:layout_height="62dp"
+        style="@style/JmtButton"
+        android:text="@string/next"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginBottom="36dp"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_sign_up_complete.xml
+++ b/presentation/src/main/res/layout/fragment_sign_up_complete.xml
@@ -36,9 +36,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/ask_profile_text"
-        android:src="@drawable/profile_icon"
+        android:src="@drawable/base_profile_image"
         android:layout_marginTop="24dp"
         android:contentDescription="@string/content_description_profile_image" />
+
+    <ImageView
+        android:id="@+id/profile_image_add_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="@id/profile_image"
+        android:src="@drawable/profile_image_add_button"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="@id/profile_image"
+        android:contentDescription="@string/content_description_profile_image_setting_button" />
 
     <TextView
         android:id="@+id/nickname_text"

--- a/presentation/src/main/res/layout/fragment_sign_up_complete.xml
+++ b/presentation/src/main/res/layout/fragment_sign_up_complete.xml
@@ -40,15 +40,20 @@
         android:layout_marginTop="24dp"
         android:contentDescription="@string/content_description_profile_image" />
 
-    <ImageView
-        android:id="@+id/profile_image_add_button"
+    <androidx.cardview.widget.CardView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="@id/profile_image"
-        android:src="@drawable/profile_image_add_button"
         android:elevation="4dp"
-        app:layout_constraintBottom_toBottomOf="@id/profile_image"
-        android:contentDescription="@string/content_description_profile_image_setting_button" />
+        app:cardCornerRadius="100dp"
+        app:layout_constraintEnd_toEndOf="@id/profile_image"
+        app:layout_constraintBottom_toBottomOf="@id/profile_image">
+        <ImageView
+            android:id="@+id/profile_image_add_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/profile_image_add_button"
+            android:contentDescription="@string/content_description_profile_image_setting_button" />
+    </androidx.cardview.widget.CardView>
 
     <TextView
         android:id="@+id/nickname_text"

--- a/presentation/src/main/res/layout/fragment_sign_up_nickname.xml
+++ b/presentation/src/main/res/layout/fragment_sign_up_nickname.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".login.SignUpNicknameFragment">
+
+    <TextView
+        android:id="@+id/ask_nickname_text"
+        android:text="@string/ask_nickname"
+        android:textAppearance="@style/title_medium_bold"
+        android:lineSpacingExtra="12dp"
+        android:layout_marginTop="56dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <org.gdsc.presentation.view.JmtEditText
+        android:id="@+id/nickname_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ask_nickname_text"
+        android:layout_marginTop="24dp"/>
+
+    <Button
+        android:id="@+id/next_btn"
+        android:text="@string/next"
+        android:layout_width="0dp"
+        android:layout_height="62dp"
+        style="@style/JmtButton"
+        android:layout_marginHorizontal="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginBottom="36dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/navigation/login_nav_graph.xml
+++ b/presentation/src/main/res/navigation/login_nav_graph.xml
@@ -10,7 +10,14 @@
         android:name="org.gdsc.presentation.login.LoginFragment"
         android:label="fragment_login"
         tools:layout="@layout/fragment_login" >
-
+        <action
+            android:id="@+id/action_loginFragment_to_signUpNicknameFragment"
+            app:destination="@id/signUpNicknameFragment" />
     </fragment>
-
+    <fragment
+        android:id="@+id/signUpNicknameFragment"
+        android:name="org.gdsc.presentation.login.SignUpNicknameFragment"
+        android:label="fragment_sign_up_nickname"
+        tools:layout="@layout/fragment_sign_up_nickname" >
+    </fragment>
 </navigation>

--- a/presentation/src/main/res/navigation/login_nav_graph.xml
+++ b/presentation/src/main/res/navigation/login_nav_graph.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/loginFragment">
+
+    <fragment
+        android:id="@+id/loginFragment"
+        android:name="org.gdsc.presentation.login.LoginFragment"
+        android:label="fragment_login"
+        tools:layout="@layout/fragment_login" >
+
+    </fragment>
+
+</navigation>

--- a/presentation/src/main/res/navigation/login_nav_graph.xml
+++ b/presentation/src/main/res/navigation/login_nav_graph.xml
@@ -19,5 +19,17 @@
         android:name="org.gdsc.presentation.login.SignUpNicknameFragment"
         android:label="fragment_sign_up_nickname"
         tools:layout="@layout/fragment_sign_up_nickname" >
+        <action
+            android:id="@+id/action_signUpNicknameFragment_to_signUpCompleteFragment"
+            app:destination="@id/signUpCompleteFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/signUpCompleteFragment"
+        android:name="org.gdsc.presentation.login.SignUpCompleteFragment"
+        android:label="fragment_sign_up_complete"
+        tools:layout="@layout/fragment_sign_up_complete" >
+        <argument
+            android:name="nickname"
+            app:argType="string" />
     </fragment>
 </navigation>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="apple_provider">apple.com</string>
 
     <string name="confirm">확인</string>
+    <string name="next">다음</string>
 
     <string name="enable_nickname">사용 가능한 닉네임입니다.</string>
     <string name="unable_nickname">사용 불가능한 닉네임입니다.</string>
@@ -11,5 +12,12 @@
     <string name="content_description_nickname_verify">닉네임 유효성 검증</string>
     <string name="continue_with_google">Google로 계속하기</string>
     <string name="continue_with_apple"><u>애플 계정으로 계속하기</u></string>
+
+    <string name="ask_nickname">반가워요\n어떻게 불러드리면 될까요?</string>
+
+    <string name="congratulation_sign_up">가입을 축하합니다!</string>
+    <string name="alert_setting_profile_image">설정하지 않으면 기본 이미지로 표시됩니다.</string>
+    <string name="suggest_set_profile_image">나의 프로필 사진을 설정해볼까요?</string>
+    <string name="content_description_profile_image">프로필 이미지</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -19,5 +19,6 @@
     <string name="alert_setting_profile_image">설정하지 않으면 기본 이미지로 표시됩니다.</string>
     <string name="suggest_set_profile_image">나의 프로필 사진을 설정해볼까요?</string>
     <string name="content_description_profile_image">프로필 이미지</string>
+    <string name="content_description_profile_image_setting_button">프로필 이미지 설정 버튼</string>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="nickname_hint">닉네임을 입력하세요.</string>
 
     <string name="content_description_nickname_verify">닉네임 유효성 검증</string>
+    <string name="continue_with_google">Google로 계속하기</string>
+    <string name="continue_with_apple"><u>애플 계정으로 계속하기</u></string>
+
 </resources>


### PR DESCRIPTION
## 개요
- Figma에 명시되어있는 회원가입 플로우에 맞춰 회원 가입 페이지 구현

## 동작 모습
![signUpFlow](https://user-images.githubusercontent.com/90144041/226505231-bf12fdd9-50f9-4601-ba2e-3d310ff1bdc9.gif)

- 프로필 설정 페이지 피그마의 이미지들 svg로 추출해서 반영
  - 카드뷰 사용해서 그림자 반영 
<img width="386" alt="Screenshot 2023-03-21 at 2 04 20 PM" src="https://user-images.githubusercontent.com/90144041/226523350-2efeedde-7b7f-434e-9b98-4043db262fe1.png">



## 남은 사항
- 구글 혹은 애플 로그인 버튼 클릭 시 가입 유무 파악 후 가입이 되어있다면 메인 페이지로, 그렇지 않으면 회원가입 flow를 타도록 변경
- 뷰모델 처리
- 닉네임 공백 처리
- 사용 가능한 닉네임 여부 및 중복 여부 확인 
- JmtButton enable이 false가 되었을 때 배경 설정