### PR TITLE
프로필 이미지 추가 버튼 애니메이션 구현

### DIFF
--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
@@ -1,10 +1,13 @@
 package org.gdsc.presentation.login
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import androidx.cardview.widget.CardView
 import androidx.fragment.app.activityViewModels
 import org.gdsc.presentation.databinding.FragmentSignUpCompleteBinding
 
@@ -26,6 +29,7 @@ class SignUpCompleteFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setProfileImageButtonAnimation()
 
         binding.nicknameText.text = viewModel.nicknameState.value
 
@@ -33,6 +37,27 @@ class SignUpCompleteFragment : Fragment() {
             // TODO: 갤러리에서 이미지 pick
         }
 
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setProfileImageButtonAnimation() {
+        binding.profileImageAddButton.setOnTouchListener { v, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    val parent = v.parent as CardView
+                    parent.animate()
+                        .scaleX(1.2f)
+                        .scaleY(1.2f)
+                }
+                MotionEvent.ACTION_UP -> {
+                    val parent = v.parent as CardView
+                    parent.animate()
+                        .scaleX(1f)
+                        .scaleY(1f)
+                }
+            }
+            false
+        }
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## 개요
- 프로필 이미지 추가 버튼 애니메이션 구현

## 동작모습
![button_animation](https://user-images.githubusercontent.com/90144041/226936697-1c9c4e41-582b-42d7-a80a-888747e61f4f.gif)
- 터치 다운 시 확장
- 터치 업 시 원본으로 돌아옴
- 터치 다운 후 버튼에서 터치 업 시 클릭 이벤트 발생
- 터치 다운 후 다른 곳에서 터치 업 시 클릭 이벤트 발생 X

## 특이사항
- svg이미지에 그림자를 주기 위하여 cardView를 사용하였습니다.
- FrameLayout을 상속받은 cardView에 애니메이션을 적용시키기 위하여 자식인 ImageView의 터치 이벤트 발생 시 부모를 찾아 애니메이션을 적용시키도록 하였습니다.