### PR TITLE
선택한 프로필 이미지 가져와서 보여주는 기능 추가

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -19,9 +19,8 @@
             android:exported="false" />
         <activity
             android:name="org.gdsc.presentation.view.MainActivity"
-            android:exported="false">
+            android:exported="false"/>
 
-        </activity>
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"
             android:value="${naverMapClientId}" />

--- a/presentation/src/main/java/org/gdsc/presentation/login/LoginActivity.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/LoginActivity.kt
@@ -2,8 +2,10 @@ package org.gdsc.presentation.login
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 import org.gdsc.presentation.databinding.ActivityLoginBinding
 
+@AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityLoginBinding

--- a/presentation/src/main/java/org/gdsc/presentation/login/PermissionFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/PermissionFragment.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.navigation.fragment.findNavController
 import org.gdsc.presentation.databinding.FragmentPermissionBinding
 
 class PermissionFragment : Fragment() {
@@ -26,7 +27,8 @@ class PermissionFragment : Fragment() {
     private val requiredPermissionsOTHER = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
     // 권한 확인 완료 후 ImagePickerFragment로 이동
     private val onSuccess: () -> Unit = {
-        PermissionFragmentDirections.actionPermissionFragmentToImagepickerFragment()
+        val action = PermissionFragmentDirections.actionPermissionFragmentToImagepickerFragment()
+        findNavController().navigate(action)
     }
 
     private val requestPermissionsLauncher = registerForActivityResult(

--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
@@ -8,10 +8,12 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.cardview.widget.CardView
+import androidx.core.net.toUri
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import org.gdsc.presentation.databinding.FragmentSignUpCompleteBinding
+import com.bumptech.glide.Glide
 
 class SignUpCompleteFragment : Fragment() {
 
@@ -27,17 +29,22 @@ class SignUpCompleteFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSignUpCompleteBinding.inflate(inflater, container, false)
-
-        args.imageUri?.let {
-            // TODO : 이미지 변경 로직
-        }
-
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setProfileImageButtonAnimation()
+
+        args.imageUri?.let {
+
+            Glide.with(binding.root)
+                .load(it.toUri())
+                .centerCrop()
+                .into(binding.profileImage)
+
+            binding.profileImage.clipToOutline = true
+        }
 
         binding.nicknameText.text = viewModel.nicknameState.value
 

--- a/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/SignUpCompleteFragment.kt
@@ -9,9 +9,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.cardview.widget.CardView
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import org.gdsc.presentation.databinding.FragmentSignUpCompleteBinding
-import org.gdsc.presentation.view.PermissionFragmentDirections
 
 class SignUpCompleteFragment : Fragment() {
 
@@ -42,8 +42,8 @@ class SignUpCompleteFragment : Fragment() {
         binding.nicknameText.text = viewModel.nicknameState.value
 
         binding.profileImageAddButton.setOnClickListener {
-            // TODO: 갤러리에서 이미지 pick
-            SignUpCompleteFragmentDirections.actionSignUpCompleteFragmentToPermissionFragment()
+            val action = SignUpCompleteFragmentDirections.actionSignUpCompleteFragmentToPermissionFragment()
+            findNavController().navigate(action)
         }
 
     }

--- a/presentation/src/main/res/drawable/background_profile.xml
+++ b/presentation/src/main/res/drawable/background_profile.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+</shape>

--- a/presentation/src/main/res/layout/fragment_sign_up_complete.xml
+++ b/presentation/src/main/res/layout/fragment_sign_up_complete.xml
@@ -31,11 +31,13 @@
     
     <ImageView
         android:id="@+id/profile_image"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="154dp"
+        android:layout_height="154dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/ask_profile_text"
+        android:scaleType="centerCrop"
+        android:background="@drawable/background_profile"
         android:src="@drawable/base_profile_image"
         android:layout_marginTop="24dp"
         android:contentDescription="@string/content_description_profile_image" />


### PR DESCRIPTION
## 개요
- 선택할 프로필 이미지 가져와서 보여주는 기능 추가
  - 동그란 이미지 뷰에 Glide로 선택한 사진 띄우도록 구현 

## 특이사항

동그란 이미지 뷰를 만들기 위하여 이미지 뷰의 background 속성을 oval로 지정하고,
ImageView.clipToOutline 속성을 true로 설정하였음.

## 동작 모습
![get_image](https://user-images.githubusercontent.com/90144041/228009691-78a42040-3b64-4a77-b605-90eac1d68cfd.gif)
