### PR TITLE
위치 정보 권한, 가져오기 & 관련 API 수정 / 기본 화면 MainActivity로 변경

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:theme="@style/Theme.JMT"
         android:usesCleartextTraffic="true">
         <activity
-            android:name="org.gdsc.presentation.view.TestActivity"
+            android:name="org.gdsc.presentation.view.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSource.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSource.kt
@@ -4,7 +4,10 @@ import org.gdsc.domain.model.RestaurantLocationInfo
 
 interface RestaurantDataSource {
 
-    suspend fun getRestaurantLocationInfo(query: String, page: Int): List<RestaurantLocationInfo>
+    suspend fun getRestaurantLocationInfo(
+        query: String, latitude: String,
+        longitude: String, page: Int
+    ): List<RestaurantLocationInfo>
 
     suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean
 }

--- a/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSourceImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSourceImpl.kt
@@ -11,10 +11,12 @@ class RestaurantDataSourceImpl @Inject constructor(
 ) : RestaurantDataSource {
     override suspend fun getRestaurantLocationInfo(
         query: String,
+        latitude: String,
+        longitude: String,
         page: Int
     ): List<RestaurantLocationInfo> {
         // TODO: 예외 처리
-        return restaurantAPI.getRestaurantLocationInfo(query, page).data
+        return restaurantAPI.getRestaurantLocationInfo(query, latitude, longitude, page).data
     }
 
     override suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean {

--- a/data/src/main/java/org/gdsc/data/network/RestaurantAPI.kt
+++ b/data/src/main/java/org/gdsc/data/network/RestaurantAPI.kt
@@ -11,6 +11,8 @@ interface RestaurantAPI {
     @GET("api/v1/restaurant/location")
     suspend fun getRestaurantLocationInfo(
         @Query("query") query: String,
+        @Query("y") latitude: String,
+        @Query("x") longitude: String,
         @Query("page") page: Int,
     ): Response<List<RestaurantLocationInfo>>
 

--- a/data/src/main/java/org/gdsc/data/repository/RestaurantRepositoryImpl.kt
+++ b/data/src/main/java/org/gdsc/data/repository/RestaurantRepositoryImpl.kt
@@ -7,9 +7,12 @@ import javax.inject.Inject
 
 class RestaurantRepositoryImpl @Inject constructor(
     private val restaurantDataSource: RestaurantDataSource
-): RestaurantRepository {
-    override suspend fun getRestaurantLocationInfo(query: String, page: Int): List<RestaurantLocationInfo> {
-        return restaurantDataSource.getRestaurantLocationInfo(query, page)
+) : RestaurantRepository {
+    override suspend fun getRestaurantLocationInfo(
+        query: String, latitude: String,
+        longitude: String, page: Int
+    ): List<RestaurantLocationInfo> {
+        return restaurantDataSource.getRestaurantLocationInfo(query, latitude, longitude, page)
     }
 
     override suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean {

--- a/domain/src/main/java/org/gdsc/domain/repository/RestaurantRepository.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/RestaurantRepository.kt
@@ -4,7 +4,10 @@ import org.gdsc.domain.model.RestaurantLocationInfo
 
 interface RestaurantRepository {
 
-    suspend fun getRestaurantLocationInfo(query: String, page: Int): List<RestaurantLocationInfo>
+    suspend fun getRestaurantLocationInfo(
+        query: String, latitude: String,
+        longitude: String, page: Int
+    ): List<RestaurantLocationInfo>
 
     suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean
 }

--- a/domain/src/main/java/org/gdsc/domain/usecase/GetRestaurantLocationInfoUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/GetRestaurantLocationInfoUseCase.kt
@@ -7,7 +7,10 @@ import javax.inject.Inject
 class GetRestaurantLocationInfoUseCase @Inject constructor(
     private val restaurantRepository: RestaurantRepository
 ) {
-    suspend operator fun invoke(query: String, page: Int): List<RestaurantLocationInfo> {
-        return restaurantRepository.getRestaurantLocationInfo(query, page)
+    suspend operator fun invoke(
+        query: String, latitude: String,
+        longitude: String, page: Int
+    ): List<RestaurantLocationInfo> {
+        return restaurantRepository.getRestaurantLocationInfo(query, latitude, longitude, page)
     }
 }

--- a/domain/src/main/java/org/gdsc/domain/util.kt
+++ b/domain/src/main/java/org/gdsc/domain/util.kt
@@ -1,0 +1,11 @@
+package org.gdsc.domain
+
+fun String.toMeterFormat(): String {
+    return if (this.length > 3) {
+        val km = this.substring(0, this.length - 3)
+        val m = this.substring(this.length - 3, this.length)
+        "$km.$m km"
+    } else {
+        "$this m"
+    }
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -113,4 +113,7 @@ dependencies {
 
     // naver map
     implementation "com.naver.maps:map-sdk:3.16.2"
+
+    // Fused Location Provider
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -19,9 +19,6 @@
         <activity
             android:name="org.gdsc.presentation.view.WebViewActivity"
             android:exported="false" />
-        <activity
-            android:name="org.gdsc.presentation.view.MainActivity"
-            android:exported="false"/>
 
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application>
         <activity

--- a/presentation/src/main/java/org/gdsc/presentation/JmtLocationManager.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/JmtLocationManager.kt
@@ -1,0 +1,46 @@
+package org.gdsc.presentation
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import androidx.core.content.ContextCompat.checkSelfPermission
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class JmtLocationManager @Inject constructor(
+    @ApplicationContext private val context: Context) {
+
+    private var fusedLocationClient: FusedLocationProviderClient =
+        LocationServices.getFusedLocationProviderClient(context)
+    private var currentLocation: Location? = null
+
+    // 위치 권한은 반드시 받아진 상태
+    suspend fun getCurrentLocation(): Location? {
+
+        return if (checkSelfPermission(
+                context, Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED && checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            fusedLocationClient.getCurrentLocation(
+                Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                null
+            ).addOnSuccessListener { location: Location? ->
+                location?.run {
+                    currentLocation = location
+                }
+            }.await()
+
+        } else currentLocation
+
+    }
+
+
+}

--- a/presentation/src/main/java/org/gdsc/presentation/view/MainActivity.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/MainActivity.kt
@@ -1,11 +1,20 @@
 package org.gdsc.presentation.view
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.ColorStateList
+import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.provider.Settings
 import android.view.View
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import org.gdsc.presentation.R
 import org.gdsc.presentation.databinding.ActivityMainBinding
@@ -18,11 +27,65 @@ class MainActivity : AppCompatActivity() {
     }
     private lateinit var binding: ActivityMainBinding
 
+    private val locationPermissionRequest = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+
+        if (permissions.all { it.value }) {
+            Toast.makeText(this, "위치 권한이 허용되었습니다!", Toast.LENGTH_SHORT).show()
+        } else {
+            showLocationPermissionDialog()
+        }
+
+    }
+
+    private fun checkLocationRequest() {
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            locationPermissionRequest.launch(
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                )
+            )
+        }
+    }
+
+    // TODO: change to JMT Dialog
+    private fun showLocationPermissionDialog() {
+        MaterialAlertDialogBuilder(this)
+            .setTitle("위치 권한 요청")
+            .setMessage("위치 권한 설정 창으로 이동할까요?")
+            .setPositiveButton("네") { _, _ ->
+
+                startActivity(
+                    Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.fromParts("package", packageName, null)
+                    )
+                )
+            }
+            .setNegativeButton("아니요") { _, _ ->
+                Toast.makeText(this, "위치 권한이 꼭 필요합니다.", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            .show()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
 
         super.onCreate(savedInstanceState)
 
         binding = ActivityMainBinding.inflate(layoutInflater)
+
+        checkLocationRequest()
+
         setContentView(binding.root)
 
         initBottomNavigationView()

--- a/presentation/src/main/java/org/gdsc/presentation/view/home/HomeFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/home/HomeFragment.kt
@@ -5,15 +5,24 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.MapView
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.gdsc.presentation.databinding.FragmentHomeBinding
 
+@AndroidEntryPoint
 class HomeFragment : Fragment() {
 
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding!!
 
     private lateinit var mapView: MapView
+
+    private val viewModel: HomeViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -25,11 +34,26 @@ class HomeFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         mapView = binding.mapView
         mapView.onCreate(savedInstanceState)
 
-        mapView.getMapAsync { map ->
-            map.uiSettings.isZoomControlEnabled = false
+
+        mapView.getMapAsync { naverMap ->
+
+            naverMap.uiSettings.isZoomControlEnabled = false
+
+            lifecycleScope.launch {
+                val currentLocation = viewModel.getCurrentLocation()
+
+                currentLocation?.let {
+                    val cameraUpdate =
+                        CameraUpdate.scrollTo(LatLng(it.latitude, it.longitude))
+                    naverMap.moveCamera(cameraUpdate)
+                }
+
+            }
+
         }
 
     }

--- a/presentation/src/main/java/org/gdsc/presentation/view/home/HomeViewModel.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/home/HomeViewModel.kt
@@ -1,0 +1,14 @@
+package org.gdsc.presentation.view.home
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.gdsc.presentation.JmtLocationManager
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val locationManager: JmtLocationManager
+) : ViewModel() {
+
+    suspend fun getCurrentLocation() = locationManager.getCurrentLocation()
+}

--- a/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/ConfirmRestaurantRegistrationFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/ConfirmRestaurantRegistrationFragment.kt
@@ -9,7 +9,11 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.content.ContextCompat.getColor
 import androidx.navigation.fragment.navArgs
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.MapView
+import com.naver.maps.map.overlay.Marker
+import org.gdsc.domain.toMeterFormat
 import org.gdsc.presentation.R
 import org.gdsc.presentation.databinding.FragmentConfirmRestaurantRegistrationBinding
 import org.gdsc.presentation.utils.deviceMetrics
@@ -68,10 +72,19 @@ class ConfirmRestaurantRegistrationFragment : Fragment() {
         mapView = binding.mapView
         mapView.onCreate(savedInstanceState)
 
-        mapView.getMapAsync { map ->
-            map.uiSettings.isZoomControlEnabled = false
-            map.uiSettings.isScaleBarEnabled = false
+        mapView.getMapAsync { naverMap ->
+            naverMap.uiSettings.isZoomControlEnabled = false
+            naverMap.uiSettings.isScaleBarEnabled = false
+
+            val marker = Marker().apply {
+                position = LatLng(navArgs.restaurantLocationInfo.y.toDouble(), navArgs.restaurantLocationInfo.x.toDouble())
+                map = naverMap
+            }
+
+            val cameraUpdate = CameraUpdate.scrollTo(LatLng(navArgs.restaurantLocationInfo.y.toDouble(), navArgs.restaurantLocationInfo.x.toDouble()))
+            naverMap.moveCamera(cameraUpdate)
         }
+
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -83,7 +96,7 @@ class ConfirmRestaurantRegistrationFragment : Fragment() {
                 navArgs.restaurantLocationInfo.placeName
 
             distanceFromCurrentLocation.text =
-                navArgs.restaurantLocationInfo.distance
+                getString(R.string.distance_from_current_location, navArgs.restaurantLocationInfo.distance.toMeterFormat())
 
             restaurantAddress.text =
                 navArgs.restaurantLocationInfo.addressName

--- a/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/RestaurantLocationInfoAdapter.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/RestaurantLocationInfoAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.gdsc.domain.model.RestaurantLocationInfo
+import org.gdsc.domain.toMeterFormat
 import org.gdsc.presentation.R
 import org.gdsc.presentation.databinding.RestaurantLocationInfoItemBinding
 
@@ -24,7 +25,11 @@ class RestaurantLocationInfoAdapter(private val onItemClicked: (RestaurantLocati
         fun bind(item: RestaurantLocationInfo) {
             setTextSpan(item.placeName)
             binding.restaurantAddress.text = item.addressName
-            binding.distanceFromCurrentLocation.text = item.distance
+            binding.distanceFromCurrentLocation.text =
+                binding.root.context.getString(
+                    R.string.distance_from_current_location,
+                    item.distance.toMeterFormat()
+                )
         }
 
         private fun setTextSpan(placeName: String) {
@@ -53,7 +58,13 @@ class RestaurantLocationInfoAdapter(private val onItemClicked: (RestaurantLocati
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RestaurantInfoViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return RestaurantInfoViewHolder(RestaurantLocationInfoItemBinding.inflate(inflater, parent, false))
+        return RestaurantInfoViewHolder(
+            RestaurantLocationInfoItemBinding.inflate(
+                inflater,
+                parent,
+                false
+            )
+        )
     }
 
     override fun onBindViewHolder(holder: RestaurantInfoViewHolder, position: Int) {

--- a/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/SearchRestaurantLocationInfoViewModel.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/SearchRestaurantLocationInfoViewModel.kt
@@ -7,17 +7,22 @@ import kotlinx.coroutines.withContext
 import org.gdsc.domain.model.RestaurantLocationInfo
 import org.gdsc.domain.usecase.CheckRestaurantRegistrationUseCase
 import org.gdsc.domain.usecase.GetRestaurantLocationInfoUseCase
+import org.gdsc.presentation.JmtLocationManager
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchRestaurantLocationInfoViewModel @Inject constructor(
+    private val locationManager: JmtLocationManager,
     private val getRestaurantLocationInfoUseCase: GetRestaurantLocationInfoUseCase,
     private val checkRestaurantRegistrationUseCase: CheckRestaurantRegistrationUseCase
 ) : ViewModel() {
 
-    suspend fun getRestaurantLocationInfo(query: String, page: Int): List<RestaurantLocationInfo> {
+    suspend fun getRestaurantLocationInfo(
+        query: String, latitude: String,
+        longitude: String, page: Int
+    ): List<RestaurantLocationInfo> {
         return withContext(viewModelScope.coroutineContext) {
-            val response = getRestaurantLocationInfoUseCase.invoke(query, page)
+            val response = getRestaurantLocationInfoUseCase.invoke(query, latitude, longitude, page)
             response
         }
     }
@@ -28,5 +33,7 @@ class SearchRestaurantLocationInfoViewModel @Inject constructor(
             response
         }
     }
+
+    suspend fun getCurrentLocation() = locationManager.getCurrentLocation()
 
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -30,4 +30,7 @@
     <string name="cancel">취소</string>
     <string name="select">선택</string>
 
+    <string name="distance_from_current_location">내 위치에서 %s</string>
+    <string name="get_location_error">위치 정보를 가져올 수 없습니다.</string>
+
 </resources>


### PR DESCRIPTION
## 개요
- 위치 정보 권한, 현재 위치정보 가져오는 기능 추가
- 맛집 위치 정보 가져올 때 현재 위치의 위,경도를 기반으로 요청하도록 변경
- 기본화면이 MainActivitiy가 되도록 변경

## 특이사항
- 위치 권한 요청을 현재 MainActivity에서 진행하고 위치 권한이 거부되면 앱이 즉시되도록 되어있음.
- 위치 정보는 JmtLocationManager에서 제공해줌. <- 해당 클래스는 Hilt로 ViewModel에 주입하여 사용
  - 위치 정보를 사용하는 순간만 이렇게 가져올지, 백그라운드에서 갱신을 지속하며 캐싱을 할지 등 정책에 따라 구현이 달라져야할 필요가 있음. 
- 에뮬에서는 구글 본사의 위치만 가져옴...

## 동작 모습
![location](https://user-images.githubusercontent.com/90144041/231345246-92d5730c-5ba0-425c-803b-459e3be87f96.gif)
