### PR TITLE
모서리의 곡률을 각각 조절할 수 있는 이미지 뷰 구현(FlexibleCornerImageView)

### DIFF
--- a/presentation/src/main/java/org/gdsc/presentation/view/custom/FlexibleCornerImageView.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/custom/FlexibleCornerImageView.kt
@@ -1,0 +1,80 @@
+package org.gdsc.presentation.view.custom
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.imageview.ShapeableImageView
+import com.google.android.material.shape.ShapeAppearanceModel
+import org.gdsc.presentation.R
+
+class FlexibleCornerImageView(context: Context, attrs: AttributeSet) :
+    ShapeableImageView(context, attrs) {
+
+    init {
+
+        context.theme.obtainStyledAttributes(
+            attrs,
+            R.styleable.FlexibleCornerImageView,
+            0, 0
+        ).apply {
+            try {
+
+                val allCornerRadius =
+                    getDimension(R.styleable.FlexibleCornerImageView_all_corner_radius, 0f)
+
+                if (allCornerRadius == 0f) {
+
+                    val topLeftRadius =
+                        getDimension(
+                            R.styleable.FlexibleCornerImageView_top_left_corner_radius, 0f
+                        )
+                    val topRightRadius = getDimension(
+                        R.styleable.FlexibleCornerImageView_top_right_corner_radius,
+                        0f
+                    )
+                    val bottomLeftRadius = getDimension(
+                        R.styleable.FlexibleCornerImageView_bottom_left_corner_radius,
+                        0f
+                    )
+                    val bottomRightRadius = getDimension(
+                        R.styleable.FlexibleCornerImageView_bottom_right_corner_radius,
+                        0f
+                    )
+
+                    setCornerRounded(
+                        listOf(
+                            topLeftRadius,
+                            topRightRadius,
+                            bottomLeftRadius,
+                            bottomRightRadius
+                        )
+                    )
+
+                } else {
+                    setCornerRounded(
+                        List(4) { allCornerRadius }
+                    )
+                }
+            } finally {
+                recycle()
+            }
+        }
+    }
+
+    private fun setCornerRounded(corners: List<Float>) {
+        this.shapeAppearanceModel = ShapeAppearanceModel.Builder()
+            .setAllCornerSizes(0f)
+            .setTopLeftCornerSize(corners[TOP_LEFT])
+            .setTopRightCornerSize(corners[TOP_RIGHT])
+            .setBottomLeftCornerSize(corners[BOTTOM_LEFT])
+            .setBottomRightCornerSize(corners[BOTTOM_RIGHT])
+            .build()
+    }
+
+    companion object {
+        private const val TOP_LEFT = 0
+        private const val TOP_RIGHT = 1
+        private const val BOTTOM_LEFT = 2
+        private const val BOTTOM_RIGHT = 3
+    }
+
+}

--- a/presentation/src/main/res/values/attrs.xml
+++ b/presentation/src/main/res/values/attrs.xml
@@ -8,4 +8,13 @@
         <attr name="verifyTextEnabled" format="boolean"/>
         <attr name="jmtEditTextHint" format="string|reference"/>
     </declare-styleable>
+
+    <declare-styleable name="FlexibleCornerImageView">
+        <attr name="top_left_corner_radius" format="dimension"/>
+        <attr name="top_right_corner_radius" format="dimension"/>
+        <attr name="bottom_left_corner_radius" format="dimension"/>
+        <attr name="bottom_right_corner_radius" format="dimension"/>
+        <attr name="all_corner_radius" format="dimension"/>
+    </declare-styleable>
+
 </resources>


### PR DESCRIPTION
## 개요
- 모서리의 곡률을 별도로 조절할 수 있는 이미지 뷰 구현(FlexibleCornerImageView)

### 사용 방법
<img width="545" alt="Screenshot 2023-05-13 at 1 32 19 AM" src="https://github.com/GDSC-Daejin/jmt-aos/assets/90144041/9dcf53dd-176e-42d6-9c02-4a12d3d502b7">

- 좌측 상단 -> app:top_left_corner_radius
- 우측 상단 ->app:top_right_corner_radius
- 우측 하단 -> app:bottom_right_corner_radius
- 좌측 하단 -> app:bottom_left_corner_radius
- 모서리 전체 -> app:all_corner_radius