### PR TITLE
CoroutineInterceptor 구현 & PostNicknameUsecase 구현

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -63,4 +63,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+
+    // data store
+    implementation 'androidx.datastore:datastore-preferences:1.0.0'
 }

--- a/data/src/main/java/org/gdsc/data/datasource/LoginDataSource.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/LoginDataSource.kt
@@ -1,6 +1,6 @@
 package org.gdsc.data.datasource
 
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 
 interface LoginDataSource {
     suspend fun postGoogleToken(token: String): TokenResponse

--- a/data/src/main/java/org/gdsc/data/datasource/LoginDataSource.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/LoginDataSource.kt
@@ -1,10 +1,10 @@
 package org.gdsc.data.datasource
 
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 
 interface LoginDataSource {
-    suspend fun postGoogleToken(token: String): LoginResponse
+    suspend fun postGoogleToken(token: String): TokenResponse
 
-    suspend fun postAppleToken(email: String, clientId: String): LoginResponse
+    suspend fun postAppleToken(email: String, clientId: String): TokenResponse
 
 }

--- a/data/src/main/java/org/gdsc/data/datasource/LoginDataSourceImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/LoginDataSourceImpl.kt
@@ -3,19 +3,19 @@ package org.gdsc.data.datasource
 import org.gdsc.data.network.LoginAPI
 import org.gdsc.domain.model.AppleLoginRequest
 import org.gdsc.domain.model.GoogleLoginRequest
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 import javax.inject.Inject
 
 
 class LoginDataSourceImpl @Inject constructor(
     private val loginAPI: LoginAPI
 ) : LoginDataSource {
-    override suspend fun postGoogleToken(token: String): LoginResponse {
-        return loginAPI.postUserGoogleToken(GoogleLoginRequest(token))
+    override suspend fun postGoogleToken(token: String): TokenResponse {
+        return loginAPI.postUserGoogleToken(GoogleLoginRequest(token)).data
     }
 
-    override suspend fun postAppleToken(email: String, clientId: String): LoginResponse {
-        return loginAPI.postUserAppleToken(AppleLoginRequest(email, clientId))
+    override suspend fun postAppleToken(email: String, clientId: String): TokenResponse {
+        return loginAPI.postUserAppleToken(AppleLoginRequest(email, clientId)).data
     }
 
 }

--- a/data/src/main/java/org/gdsc/data/datasource/LoginDataSourceImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/LoginDataSourceImpl.kt
@@ -1,9 +1,9 @@
 package org.gdsc.data.datasource
 
 import org.gdsc.data.network.LoginAPI
-import org.gdsc.domain.model.AppleLoginRequest
-import org.gdsc.domain.model.GoogleLoginRequest
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.request.AppleLoginRequest
+import org.gdsc.domain.model.request.GoogleLoginRequest
+import org.gdsc.domain.model.response.TokenResponse
 import javax.inject.Inject
 
 

--- a/data/src/main/java/org/gdsc/data/datasource/TokenManagerImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/TokenManagerImpl.kt
@@ -8,7 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.gdsc.domain.Empty
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 import org.gdsc.domain.repository.TokenManager
 import javax.inject.Inject
 

--- a/data/src/main/java/org/gdsc/data/datasource/TokenManagerImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/TokenManagerImpl.kt
@@ -1,0 +1,59 @@
+package org.gdsc.data.datasource
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.gdsc.domain.Empty
+import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Inject
+
+class TokenManagerImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+): TokenManager {
+
+    override suspend fun saveTokenInfo(tokenResponse: TokenResponse) {
+        dataStore.edit { preferences ->
+            preferences[ACCESS_TOKEN] = tokenResponse.accessToken
+            preferences[ACCESS_TOKEN_EXPIRES_IN] = tokenResponse.accessTokenExpiresIn
+            preferences[GRANT_TYPE] = tokenResponse.grantType
+            preferences[REFRESH_TOKEN] = tokenResponse.refreshToken
+        }
+    }
+
+    override suspend fun getAccessToken(): String {
+        return dataStore.data.map { preferences ->
+            preferences[ACCESS_TOKEN]
+        }.first() ?: String.Empty
+    }
+
+    override suspend fun getAccessTokenExpiresIn(): Long {
+        return dataStore.data.map { preferences ->
+            preferences[ACCESS_TOKEN_EXPIRES_IN]
+        }.first() ?: -1L
+    }
+
+    override suspend fun getGrantType(): String {
+        return dataStore.data.map { preferences ->
+            preferences[GRANT_TYPE]
+        }.first() ?: String.Empty
+    }
+
+    override suspend fun getRefreshToken(): String {
+        return dataStore.data.map { preferences ->
+            preferences[REFRESH_TOKEN]
+        }.first() ?: String.Empty
+    }
+
+    companion object {
+        private val ACCESS_TOKEN = stringPreferencesKey("accessToken")
+        private val ACCESS_TOKEN_EXPIRES_IN = longPreferencesKey("accessTokenExpiresIn")
+        private val GRANT_TYPE = stringPreferencesKey("grantType")
+        private val REFRESH_TOKEN = stringPreferencesKey("refreshToken")
+    }
+
+}

--- a/data/src/main/java/org/gdsc/data/datasource/UserDataSource.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/UserDataSource.kt
@@ -1,0 +1,9 @@
+package org.gdsc.data.datasource
+
+import org.gdsc.domain.model.request.NicknameRequest
+import org.gdsc.domain.model.response.NicknameResponse
+
+interface UserDataSource {
+
+    suspend fun postNickname(nicknameRequest: NicknameRequest): NicknameResponse
+}

--- a/data/src/main/java/org/gdsc/data/datasource/UserDataSourceImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/UserDataSourceImpl.kt
@@ -1,0 +1,14 @@
+package org.gdsc.data.datasource
+
+import org.gdsc.data.network.UserAPI
+import org.gdsc.domain.model.request.NicknameRequest
+import org.gdsc.domain.model.response.NicknameResponse
+import javax.inject.Inject
+
+class UserDataSourceImpl @Inject constructor(
+    private val userAPI: UserAPI
+) : UserDataSource {
+    override suspend fun postNickname(nicknameRequest: NicknameRequest): NicknameResponse {
+        return userAPI.postNickname(nicknameRequest).data
+    }
+}

--- a/data/src/main/java/org/gdsc/data/di/ApiModule.kt
+++ b/data/src/main/java/org/gdsc/data/di/ApiModule.kt
@@ -1,0 +1,35 @@
+package org.gdsc.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.gdsc.data.network.LoginAPI
+import org.gdsc.data.network.RestaurantAPI
+import org.gdsc.data.network.UserAPI
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ApiModule {
+
+    @Provides
+    @Singleton
+    fun provideLoginApi(@NormalClient retrofit: Retrofit): LoginAPI {
+        return retrofit.create(LoginAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRestaurantApi(@NormalClient retrofit: Retrofit): RestaurantAPI {
+        return retrofit.create(RestaurantAPI::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserApi(@AuthClient retrofit: Retrofit): UserAPI {
+        return retrofit.create(UserAPI::class.java)
+    }
+
+}

--- a/data/src/main/java/org/gdsc/data/di/NetworkModule.kt
+++ b/data/src/main/java/org/gdsc/data/di/NetworkModule.kt
@@ -7,9 +7,6 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.gdsc.data.network.AuthInterceptor
-import org.gdsc.data.network.LoginAPI
-import org.gdsc.data.network.RestaurantAPI
-import org.gdsc.data.network.UserAPI
 import org.gdsc.domain.repository.TokenManager
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -18,7 +15,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 class NetworkModule {
-
 
     @NormalClient
     @Provides
@@ -49,24 +45,6 @@ class NetworkModule {
                     .build()
             )
             .build()
-    }
-
-    @Provides
-    @Singleton
-    fun provideLoginApi(@NormalClient retrofit: Retrofit): LoginAPI {
-        return retrofit.create(LoginAPI::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun provideRestaurantApi(@NormalClient retrofit: Retrofit): RestaurantAPI {
-        return retrofit.create(RestaurantAPI::class.java)
-    }
-
-    @Provides
-    @Singleton
-    fun provideUserApi(@AuthClient retrofit: Retrofit): UserAPI {
-        return retrofit.create(UserAPI::class.java)
     }
 
     companion object {

--- a/data/src/main/java/org/gdsc/data/di/NetworkModule.kt
+++ b/data/src/main/java/org/gdsc/data/di/NetworkModule.kt
@@ -6,8 +6,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.gdsc.data.network.AuthInterceptor
 import org.gdsc.data.network.LoginAPI
 import org.gdsc.data.network.RestaurantAPI
+import org.gdsc.data.network.UserAPI
+import org.gdsc.domain.repository.TokenManager
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -16,32 +19,66 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 class NetworkModule {
 
+
+    @NormalClient
     @Provides
     @Singleton
     fun provideApiClient(): Retrofit {
 
-        val clientBuilder = OkHttpClient.Builder()
-        val loggingInterceptor = HttpLoggingInterceptor()
-        loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
-        clientBuilder.addInterceptor(loggingInterceptor)
+        return Retrofit
+            .Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(
+                baseClientBuilder.build()
+            ).build()
+    }
+
+    @AuthClient
+    @Provides
+    @Singleton
+    fun provideAuthorizedApiClient(tokenManager: TokenManager): Retrofit {
 
         return Retrofit
             .Builder()
-            .baseUrl("http://13.209.81.126:8080/")
+            .baseUrl(BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
-            .client(clientBuilder.build()).build()
+            .client(
+                baseClientBuilder
+                    .addInterceptor(AuthInterceptor(tokenManager))
+                    .build()
+            )
+            .build()
     }
 
     @Provides
     @Singleton
-    fun provideLoginApi(retrofit: Retrofit): LoginAPI {
+    fun provideLoginApi(@NormalClient retrofit: Retrofit): LoginAPI {
         return retrofit.create(LoginAPI::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideRestaurantApi(retrofit: Retrofit): RestaurantAPI {
+    fun provideRestaurantApi(@NormalClient retrofit: Retrofit): RestaurantAPI {
         return retrofit.create(RestaurantAPI::class.java)
     }
 
+    @Provides
+    @Singleton
+    fun provideUserApi(@AuthClient retrofit: Retrofit): UserAPI {
+        return retrofit.create(UserAPI::class.java)
+    }
+
+    companion object {
+        private const val BASE_URL = "http://13.209.81.126:8080/"
+        private val baseClientBuilder: OkHttpClient.Builder
+            get() = run {
+                val clientBuilder = OkHttpClient.Builder()
+                val loggingInterceptor = HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BODY
+                }
+                return clientBuilder.addInterceptor(loggingInterceptor)
+            }
+
+    }
 }

--- a/data/src/main/java/org/gdsc/data/di/Qualifiers.kt
+++ b/data/src/main/java/org/gdsc/data/di/Qualifiers.kt
@@ -1,0 +1,11 @@
+package org.gdsc.data.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NormalClient

--- a/data/src/main/java/org/gdsc/data/di/TokenModule.kt
+++ b/data/src/main/java/org/gdsc/data/di/TokenModule.kt
@@ -1,0 +1,30 @@
+package org.gdsc.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import org.gdsc.data.datasource.TokenManagerImpl
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class TokenModule {
+
+    private val TOKEN_INFO_STORAGE = "token_info_storage"
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = TOKEN_INFO_STORAGE)
+
+    @Provides
+    @Singleton
+    fun provideTokenManager(@ApplicationContext context: Context): TokenManager {
+        return TokenManagerImpl(context.dataStore)
+    }
+
+}

--- a/data/src/main/java/org/gdsc/data/di/UserModule.kt
+++ b/data/src/main/java/org/gdsc/data/di/UserModule.kt
@@ -1,0 +1,24 @@
+package org.gdsc.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.gdsc.data.datasource.UserDataSource
+import org.gdsc.data.datasource.UserDataSourceImpl
+import org.gdsc.data.repository.UserRepositoryImpl
+import org.gdsc.domain.repository.UserRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UserModule {
+
+    @Singleton
+    @Binds
+    abstract fun bindUserDataSource(userDataSourceImpl: UserDataSourceImpl): UserDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository
+}

--- a/data/src/main/java/org/gdsc/data/network/Interceptors.kt
+++ b/data/src/main/java/org/gdsc/data/network/Interceptors.kt
@@ -1,0 +1,37 @@
+package org.gdsc.data.network
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import org.gdsc.domain.repository.TokenManager
+import java.io.IOException
+import javax.inject.Inject
+
+// reference: https://github.com/square/okhttp/issues/7164
+@Suppress("potential danger of runBlocking")
+interface CoroutineInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return runBlocking {
+            try {
+                interceptSuspend(chain)
+            } catch (ce: CancellationException) {
+                throw IOException(ce)
+            }
+        }
+    }
+    suspend fun interceptSuspend(chain: Interceptor.Chain): Response
+}
+
+class AuthInterceptor @Inject constructor(
+    private val tokenManager: TokenManager
+) : CoroutineInterceptor {
+
+    override suspend fun interceptSuspend(chain: Interceptor.Chain): Response {
+        val token = "Bearer ${tokenManager.getAccessToken()}"
+        val newRequest = chain.request().newBuilder()
+            .addHeader("Authorization", token)
+            .build()
+        return chain.proceed(newRequest)
+    }
+}

--- a/data/src/main/java/org/gdsc/data/network/LoginAPI.kt
+++ b/data/src/main/java/org/gdsc/data/network/LoginAPI.kt
@@ -2,9 +2,9 @@ package org.gdsc.data.network
 
 
 import org.gdsc.data.model.Response
-import org.gdsc.domain.model.GoogleLoginRequest
-import org.gdsc.domain.model.AppleLoginRequest
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.request.GoogleLoginRequest
+import org.gdsc.domain.model.request.AppleLoginRequest
+import org.gdsc.domain.model.response.TokenResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/data/src/main/java/org/gdsc/data/network/LoginAPI.kt
+++ b/data/src/main/java/org/gdsc/data/network/LoginAPI.kt
@@ -1,9 +1,10 @@
 package org.gdsc.data.network
 
 
+import org.gdsc.data.model.Response
 import org.gdsc.domain.model.GoogleLoginRequest
 import org.gdsc.domain.model.AppleLoginRequest
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -11,11 +12,11 @@ interface LoginAPI {
     @POST("api/v1/auth/google")
     suspend fun postUserGoogleToken(
         @Body request: GoogleLoginRequest
-    ): LoginResponse
+    ): Response<TokenResponse>
 
     @POST("api/v1/auth/android/apple")
     suspend fun postUserAppleToken(
         @Body request: AppleLoginRequest
-    ): LoginResponse
+    ): Response<TokenResponse>
 
 }

--- a/data/src/main/java/org/gdsc/data/network/UserAPI.kt
+++ b/data/src/main/java/org/gdsc/data/network/UserAPI.kt
@@ -1,0 +1,13 @@
+package org.gdsc.data.network
+
+import org.gdsc.data.model.Response
+import org.gdsc.domain.model.request.NicknameRequest
+import org.gdsc.domain.model.response.NicknameResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface UserAPI {
+
+    @POST("api/v1/user/nickname")
+    suspend fun postNickname(@Body nicknameRequest: NicknameRequest): Response<NicknameResponse>
+}

--- a/data/src/main/java/org/gdsc/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/org/gdsc/data/repository/LoginRepositoryImpl.kt
@@ -1,18 +1,18 @@
 package org.gdsc.data.repository
 
 import org.gdsc.data.datasource.LoginDataSource
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 import org.gdsc.domain.repository.LoginRepository
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(private val loginDataSource: LoginDataSource) :
     LoginRepository {
 
-    override suspend fun postGoogleToken(token: String): LoginResponse {
+    override suspend fun postGoogleToken(token: String): TokenResponse {
         return loginDataSource.postGoogleToken(token)
     }
 
-    override suspend fun postAppleToken(email: String, clientId: String): LoginResponse {
+    override suspend fun postAppleToken(email: String, clientId: String): TokenResponse {
         return loginDataSource.postAppleToken(email, clientId)
     }
 

--- a/data/src/main/java/org/gdsc/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/org/gdsc/data/repository/LoginRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package org.gdsc.data.repository
 
 import org.gdsc.data.datasource.LoginDataSource
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 import org.gdsc.domain.repository.LoginRepository
 import javax.inject.Inject
 

--- a/data/src/main/java/org/gdsc/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/org/gdsc/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package org.gdsc.data.repository
+
+import org.gdsc.data.datasource.UserDataSource
+import org.gdsc.domain.model.request.NicknameRequest
+import org.gdsc.domain.model.response.NicknameResponse
+import org.gdsc.domain.repository.UserRepository
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val userDataSource: UserDataSource
+) : UserRepository {
+    override suspend fun postNickname(nicknameRequest: NicknameRequest): NicknameResponse {
+        return userDataSource.postNickname(nicknameRequest)
+    }
+
+}

--- a/domain/src/main/java/org/gdsc/domain/model/TokenResponse.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/TokenResponse.kt
@@ -1,12 +1,6 @@
 package org.gdsc.domain.model
 
-data class LoginResponse(
-    val code: String,
-    val `data`: Data,
-    val message: String
-)
-
-data class Data(
+data class TokenResponse(
     val accessToken: String,
     val accessTokenExpiresIn: Long,
     val grantType: String,

--- a/domain/src/main/java/org/gdsc/domain/model/request/LoginRequest.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/request/LoginRequest.kt
@@ -1,4 +1,4 @@
-package org.gdsc.domain.model
+package org.gdsc.domain.model.request
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName

--- a/domain/src/main/java/org/gdsc/domain/model/request/NicknameRequest.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/request/NicknameRequest.kt
@@ -1,0 +1,5 @@
+package org.gdsc.domain.model.request
+
+data class NicknameRequest(
+    val nickname: String
+)

--- a/domain/src/main/java/org/gdsc/domain/model/response/NicknameResponse.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/response/NicknameResponse.kt
@@ -1,0 +1,6 @@
+package org.gdsc.domain.model.response
+
+data class NicknameResponse(
+    val email: String,
+    val nickname: String
+)

--- a/domain/src/main/java/org/gdsc/domain/model/response/TokenResponse.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/response/TokenResponse.kt
@@ -1,4 +1,4 @@
-package org.gdsc.domain.model
+package org.gdsc.domain.model.response
 
 data class TokenResponse(
     val accessToken: String,

--- a/domain/src/main/java/org/gdsc/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/LoginRepository.kt
@@ -1,11 +1,11 @@
 package org.gdsc.domain.repository
 
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 
 interface LoginRepository {
 
-    suspend fun postGoogleToken(token: String): LoginResponse
+    suspend fun postGoogleToken(token: String): TokenResponse
 
-    suspend fun postAppleToken(email: String, clientId: String): LoginResponse
+    suspend fun postAppleToken(email: String, clientId: String): TokenResponse
 
 }

--- a/domain/src/main/java/org/gdsc/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/LoginRepository.kt
@@ -1,6 +1,6 @@
 package org.gdsc.domain.repository
 
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 
 interface LoginRepository {
 

--- a/domain/src/main/java/org/gdsc/domain/repository/TokenManager.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/TokenManager.kt
@@ -1,0 +1,17 @@
+package org.gdsc.domain.repository
+
+import org.gdsc.domain.model.TokenResponse
+
+interface TokenManager {
+
+    suspend fun saveTokenInfo(tokenResponse: TokenResponse)
+
+    suspend fun getAccessToken(): String
+
+    suspend fun getAccessTokenExpiresIn(): Long
+
+    suspend fun getGrantType(): String
+
+    suspend fun getRefreshToken(): String
+    
+}

--- a/domain/src/main/java/org/gdsc/domain/repository/TokenManager.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/TokenManager.kt
@@ -1,6 +1,6 @@
 package org.gdsc.domain.repository
 
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 
 interface TokenManager {
 

--- a/domain/src/main/java/org/gdsc/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/UserRepository.kt
@@ -1,0 +1,9 @@
+package org.gdsc.domain.repository
+
+import org.gdsc.domain.model.request.NicknameRequest
+import org.gdsc.domain.model.response.NicknameResponse
+
+interface UserRepository {
+
+    suspend fun postNickname(nicknameRequest: NicknameRequest): NicknameResponse
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/PostAppleTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/PostAppleTokenUseCase.kt
@@ -1,13 +1,13 @@
 package org.gdsc.domain.usecase
 
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 import org.gdsc.domain.repository.LoginRepository
 import javax.inject.Inject
 
 class PostAppleTokenUseCase @Inject constructor(
     private val loginRepository: LoginRepository
 ) {
-    suspend operator fun invoke(email: String, clientId: String): LoginResponse {
+    suspend operator fun invoke(email: String, clientId: String): TokenResponse {
         return loginRepository.postAppleToken(email, clientId)
     }
 }

--- a/domain/src/main/java/org/gdsc/domain/usecase/PostAppleTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/PostAppleTokenUseCase.kt
@@ -1,6 +1,6 @@
 package org.gdsc.domain.usecase
 
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 import org.gdsc.domain.repository.LoginRepository
 import javax.inject.Inject
 

--- a/domain/src/main/java/org/gdsc/domain/usecase/PostGoogleTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/PostGoogleTokenUseCase.kt
@@ -1,6 +1,6 @@
 package org.gdsc.domain.usecase
 
-import org.gdsc.domain.model.LoginResponse
+import org.gdsc.domain.model.TokenResponse
 import org.gdsc.domain.repository.LoginRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 class PostGoogleTokenUseCase @Inject constructor(
     private val loginRepository: LoginRepository
 ) {
-    suspend operator fun invoke(token: String): LoginResponse {
+    suspend operator fun invoke(token: String): TokenResponse {
         return loginRepository.postGoogleToken(token)
     }
 }

--- a/domain/src/main/java/org/gdsc/domain/usecase/PostGoogleTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/PostGoogleTokenUseCase.kt
@@ -1,6 +1,6 @@
 package org.gdsc.domain.usecase
 
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 import org.gdsc.domain.repository.LoginRepository
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/domain/src/main/java/org/gdsc/domain/usecase/PostNicknameUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/PostNicknameUseCase.kt
@@ -1,0 +1,12 @@
+package org.gdsc.domain.usecase
+
+import org.gdsc.domain.model.request.NicknameRequest
+import org.gdsc.domain.repository.UserRepository
+import javax.inject.Inject
+
+class PostNicknameUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(nickname: String) =
+        userRepository.postNickname(NicknameRequest(nickname))
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/token/GetAccessTokenExpiresInUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/token/GetAccessTokenExpiresInUseCase.kt
@@ -1,0 +1,13 @@
+package org.gdsc.domain.usecase.token
+
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Inject
+
+class GetAccessTokenExpiresInUseCase @Inject constructor(
+    private val tokenManager: TokenManager
+) {
+
+    suspend operator fun invoke(): Long {
+        return tokenManager.getAccessTokenExpiresIn()
+    }
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/token/GetAccessTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/token/GetAccessTokenUseCase.kt
@@ -1,0 +1,13 @@
+package org.gdsc.domain.usecase.token
+
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Inject
+
+class GetAccessTokenUseCase @Inject constructor(
+    private val tokenManager: TokenManager
+) {
+
+    suspend operator fun invoke(): String {
+        return tokenManager.getAccessToken()
+    }
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/token/GetGrantTypeUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/token/GetGrantTypeUseCase.kt
@@ -1,0 +1,13 @@
+package org.gdsc.domain.usecase.token
+
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Inject
+
+class GetGrantTypeUseCase @Inject constructor(
+    private val tokenManager: TokenManager
+) {
+
+    suspend operator fun invoke(): String {
+        return tokenManager.getGrantType()
+    }
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/token/GetRefreshTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/token/GetRefreshTokenUseCase.kt
@@ -1,0 +1,13 @@
+package org.gdsc.domain.usecase.token
+
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Inject
+
+class GetRefreshTokenUseCase @Inject constructor(
+    private val tokenManager: TokenManager
+) {
+
+    suspend operator fun invoke(): String {
+        return tokenManager.getRefreshToken()
+    }
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/token/SaveTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/token/SaveTokenUseCase.kt
@@ -1,6 +1,6 @@
 package org.gdsc.domain.usecase.token
 
-import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.model.response.TokenResponse
 import org.gdsc.domain.repository.TokenManager
 import javax.inject.Inject
 

--- a/domain/src/main/java/org/gdsc/domain/usecase/token/SaveTokenUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/token/SaveTokenUseCase.kt
@@ -1,0 +1,17 @@
+package org.gdsc.domain.usecase.token
+
+import org.gdsc.domain.model.TokenResponse
+import org.gdsc.domain.repository.TokenManager
+import javax.inject.Inject
+
+class SaveTokenUseCase @Inject constructor(
+    private val tokenManager: TokenManager,
+){
+
+    suspend operator fun invoke(
+        response: TokenResponse
+    ) {
+        tokenManager.saveTokenInfo(response)
+
+    }
+}

--- a/presentation/src/main/java/org/gdsc/presentation/view/LoginManager.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/LoginManager.kt
@@ -6,29 +6,36 @@ import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.SignInClient
 import org.gdsc.presentation.R
 import com.google.firebase.auth.FirebaseAuth
-import kotlin.coroutines.suspendCoroutine
-class LoginManager {
-    val auth = FirebaseAuth.getInstance()
-    lateinit var oneTapClient: SignInClient
-    suspend fun signInIntent(activity: Activity)  = suspendCoroutine { continuation ->
-        oneTapClient = Identity.getSignInClient(activity)
-        val signInRequest = BeginSignInRequest.builder()
-            .setPasswordRequestOptions(BeginSignInRequest.PasswordRequestOptions.builder()
-                .setSupported(true)
-                .build())
-            .setGoogleIdTokenRequestOptions(
-                BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
-                    .setSupported(true)
-                    .setServerClientId(activity.getString(R.string.my_web_client_id))
-                    .setFilterByAuthorizedAccounts(false)
-                    .build())
-            .setAutoSelectEnabled(true)
-            .build()
+import kotlinx.coroutines.suspendCancellableCoroutine
 
-        oneTapClient.beginSignIn(signInRequest)
-            .addOnFailureListener { continuation.resumeWith(Result.failure(it)) }
-            .addOnSuccessListener {
-                continuation.resumeWith(Result.success(it.pendingIntent))
-            }
-    }
+class LoginManager {
+
+    val auth = FirebaseAuth.getInstance()
+
+    lateinit var oneTapClient: SignInClient
+    suspend fun signInIntent(activity: Activity) =
+        suspendCancellableCoroutine { cancellableContinuation ->
+            oneTapClient = Identity.getSignInClient(activity)
+            val signInRequest = BeginSignInRequest.builder()
+                .setPasswordRequestOptions(
+                    BeginSignInRequest.PasswordRequestOptions.builder()
+                        .setSupported(true)
+                        .build()
+                )
+                .setGoogleIdTokenRequestOptions(
+                    BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
+                        .setSupported(true)
+                        .setServerClientId(activity.getString(R.string.my_web_client_id))
+                        .setFilterByAuthorizedAccounts(false)
+                        .build()
+                )
+                .setAutoSelectEnabled(true)
+                .build()
+
+            oneTapClient.beginSignIn(signInRequest)
+                .addOnFailureListener { cancellableContinuation.resumeWith(Result.failure(it)) }
+                .addOnSuccessListener {
+                    cancellableContinuation.resumeWith(Result.success(it.pendingIntent))
+                }
+        }
 }


### PR DESCRIPTION
## 개요
- CoroutineInterceptor 구현
  - Token을 Interceptor에서 매번 가져오기 위함(suspend)
    - Token을 매번 DataStore에서 가져오기 때문에 accessToken의 유효성은 다른 곳에서만 신경쓰면 됨
    - runBlocking의 잠재적 위험이 존재
- PostNicknameUseCase 구현
  - Auth가 필요한 Client 별도로 구현 후 Qualifier 사용    
