### PR TITLE
맛집 수정 기능 구현, WebAppbinterface 기능 추가 및 설정

### DIFF
--- a/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSource.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSource.kt
@@ -1,7 +1,9 @@
 package org.gdsc.data.datasource
 
 import org.gdsc.domain.model.RestaurantLocationInfo
+import org.gdsc.domain.model.request.ModifyRestaurantInfoRequest
 import org.gdsc.domain.model.request.RestaurantRegistrationRequest
+import org.gdsc.domain.model.response.RestaurantInfoResponse
 
 interface RestaurantDataSource {
 
@@ -10,9 +12,13 @@ interface RestaurantDataSource {
         longitude: String, page: Int
     ): List<RestaurantLocationInfo>
 
+    suspend fun getRecommendRestaurantInfo(recommendRestaurantId: Int): RestaurantInfoResponse
+
     suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean
 
     suspend fun postRestaurantLocationInfo(restaurantLocationInfo: RestaurantLocationInfo): String
 
     suspend fun postRestaurantInfo(restaurantRegistrationRequest: RestaurantRegistrationRequest): String
+
+    suspend fun putRestaurantInfo(putRestaurantInfoRequest: ModifyRestaurantInfoRequest): String
 }

--- a/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSourceImpl.kt
+++ b/data/src/main/java/org/gdsc/data/datasource/RestaurantDataSourceImpl.kt
@@ -1,11 +1,12 @@
 package org.gdsc.data.datasource
 
-import android.util.Log
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.gdsc.data.network.RestaurantAPI
 import org.gdsc.domain.RestaurantRegistrationState
 import org.gdsc.domain.model.RestaurantLocationInfo
+import org.gdsc.domain.model.request.ModifyRestaurantInfoRequest
 import org.gdsc.domain.model.request.RestaurantRegistrationRequest
+import org.gdsc.domain.model.response.RestaurantInfoResponse
 import retrofit2.HttpException
 import javax.inject.Inject
 
@@ -20,6 +21,10 @@ class RestaurantDataSourceImpl @Inject constructor(
     ): List<RestaurantLocationInfo> {
         // TODO: 예외 처리
         return restaurantAPI.getRestaurantLocationInfo(query, latitude, longitude, page).data
+    }
+
+    override suspend fun getRecommendRestaurantInfo(recommendRestaurantId: Int): RestaurantInfoResponse {
+        return restaurantAPI.getRecommendRestaurantInfo(recommendRestaurantId).data
     }
 
     override suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean {
@@ -62,4 +67,10 @@ class RestaurantDataSourceImpl @Inject constructor(
             pictures = restaurantRegistrationRequest.pictures
         ).data.recommendRestaurantId
     }
+
+    override suspend fun putRestaurantInfo(putRestaurantInfoRequest: ModifyRestaurantInfoRequest): String {
+        return restaurantAPI.putRestaurantInfo(putRestaurantInfoRequest).data
+    }
+
+
 }

--- a/data/src/main/java/org/gdsc/data/network/RestaurantAPI.kt
+++ b/data/src/main/java/org/gdsc/data/network/RestaurantAPI.kt
@@ -4,11 +4,14 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import org.gdsc.data.model.Response
 import org.gdsc.domain.model.RestaurantLocationInfo
+import org.gdsc.domain.model.request.ModifyRestaurantInfoRequest
+import org.gdsc.domain.model.response.RestaurantInfoResponse
 import org.gdsc.domain.model.response.RestaurantRegistrationResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Part
 import retrofit2.http.PartMap
 import retrofit2.http.Path
@@ -23,6 +26,11 @@ interface RestaurantAPI {
         @Query("x") longitude: String,
         @Query("page") page: Int,
     ): Response<List<RestaurantLocationInfo>>
+
+    @GET("api/v1/restaurant/{recommendRestaurantId}")
+    suspend fun getRecommendRestaurantInfo(
+        @Path("recommendRestaurantId") recommendRestaurantId: Int,
+    ): Response<RestaurantInfoResponse>
 
     @GET("api/v1/restaurant/registration/{kakaoSubId}")
     suspend fun checkRestaurantRegistration(
@@ -40,4 +48,9 @@ interface RestaurantAPI {
         @PartMap restaurantRegistrationRequest: Map<String, @JvmSuppressWildcards RequestBody>,
         @Part pictures: List<MultipartBody.Part>,
     ): Response<RestaurantRegistrationResponse>
+
+    @PUT("api/v1/restaurant")
+    suspend fun putRestaurantInfo(
+        @Body putRestaurantInfoRequest: ModifyRestaurantInfoRequest,
+    ): Response<String>
 }

--- a/data/src/main/java/org/gdsc/data/repository/RestaurantRepositoryImpl.kt
+++ b/data/src/main/java/org/gdsc/data/repository/RestaurantRepositoryImpl.kt
@@ -2,7 +2,9 @@ package org.gdsc.data.repository
 
 import org.gdsc.data.datasource.RestaurantDataSource
 import org.gdsc.domain.model.RestaurantLocationInfo
+import org.gdsc.domain.model.request.ModifyRestaurantInfoRequest
 import org.gdsc.domain.model.request.RestaurantRegistrationRequest
+import org.gdsc.domain.model.response.RestaurantInfoResponse
 import org.gdsc.domain.repository.RestaurantRepository
 import javax.inject.Inject
 
@@ -16,6 +18,10 @@ class RestaurantRepositoryImpl @Inject constructor(
         return restaurantDataSource.getRestaurantLocationInfo(query, latitude, longitude, page)
     }
 
+    override suspend fun getRecommendRestaurantInfo(recommendRestaurantId: Int): RestaurantInfoResponse {
+        return restaurantDataSource.getRecommendRestaurantInfo(recommendRestaurantId)
+    }
+
     override suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean {
         return restaurantDataSource.checkRestaurantRegistration(kakaoSubId)
     }
@@ -26,5 +32,9 @@ class RestaurantRepositoryImpl @Inject constructor(
 
     override suspend fun postRestaurantInfo(restaurantRegistrationRequest: RestaurantRegistrationRequest): String {
         return restaurantDataSource.postRestaurantInfo(restaurantRegistrationRequest)
+    }
+
+    override suspend fun putRestaurantInfo(putRestaurantInfoRequest: ModifyRestaurantInfoRequest): String {
+        return restaurantDataSource.putRestaurantInfo(putRestaurantInfoRequest)
     }
 }

--- a/domain/src/main/java/org/gdsc/domain/FoodCategory.kt
+++ b/domain/src/main/java/org/gdsc/domain/FoodCategory.kt
@@ -25,5 +25,6 @@ enum class FoodCategory(val id: Long, val text: String) {
 
         val ALL = values().toList().dropLast(1)
         fun fromId(id: Long) = values().first { it.id == id }
+        fun fromName(name: String) = values().first { it.text == name }
     }
 }

--- a/domain/src/main/java/org/gdsc/domain/model/request/ModifyRestaurantInfoRequest.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/request/ModifyRestaurantInfoRequest.kt
@@ -1,0 +1,10 @@
+package org.gdsc.domain.model.request
+
+data class ModifyRestaurantInfoRequest(
+    val canDrinkLiquor: Boolean,
+    val categoryId: Int,
+    val goWellWithLiquor: String,
+    val id: Int,
+    val introduce: String,
+    val recommendMenu: String
+)

--- a/domain/src/main/java/org/gdsc/domain/model/response/RestaurantInfoResponse.kt
+++ b/domain/src/main/java/org/gdsc/domain/model/response/RestaurantInfoResponse.kt
@@ -1,0 +1,20 @@
+package org.gdsc.domain.model.response
+
+data class RestaurantInfoResponse(
+    val address: String,
+    val canDrinkLiquor: Boolean,
+    val category: String,
+    val goWellWithLiquor: String,
+    val introduce: String,
+    val name: String,
+    val phone: String,
+    val pictures: List<String>,
+    val placeUrl: String,
+    val recommendMenu: String,
+    val roadAddress: String,
+    val userId: Int,
+    val userNickName: String,
+    val userProfileImageUrl: String,
+    val x: Double,
+    val y: Double
+)

--- a/domain/src/main/java/org/gdsc/domain/repository/RestaurantRepository.kt
+++ b/domain/src/main/java/org/gdsc/domain/repository/RestaurantRepository.kt
@@ -1,7 +1,9 @@
 package org.gdsc.domain.repository
 
 import org.gdsc.domain.model.RestaurantLocationInfo
+import org.gdsc.domain.model.request.ModifyRestaurantInfoRequest
 import org.gdsc.domain.model.request.RestaurantRegistrationRequest
+import org.gdsc.domain.model.response.RestaurantInfoResponse
 
 interface RestaurantRepository {
 
@@ -10,9 +12,13 @@ interface RestaurantRepository {
         longitude: String, page: Int
     ): List<RestaurantLocationInfo>
 
+    suspend fun getRecommendRestaurantInfo(recommendRestaurantId: Int): RestaurantInfoResponse
+
     suspend fun checkRestaurantRegistration(kakaoSubId: String): Boolean
 
     suspend fun postRestaurantLocationInfo(restaurantLocationInfo: RestaurantLocationInfo): String
 
     suspend fun postRestaurantInfo(restaurantRegistrationRequest: RestaurantRegistrationRequest): String
+
+    suspend fun putRestaurantInfo(putRestaurantInfoRequest: ModifyRestaurantInfoRequest): String
 }

--- a/domain/src/main/java/org/gdsc/domain/usecase/GetRestaurantInfoUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/GetRestaurantInfoUseCase.kt
@@ -1,0 +1,14 @@
+package org.gdsc.domain.usecase
+
+import org.gdsc.domain.model.response.RestaurantInfoResponse
+import org.gdsc.domain.repository.RestaurantRepository
+import javax.inject.Inject
+
+class GetRestaurantInfoUseCase @Inject constructor(
+    private val restaurantRepository: RestaurantRepository
+){
+
+    suspend operator fun invoke(recommendRestaurantId: Int): RestaurantInfoResponse {
+        return restaurantRepository.getRecommendRestaurantInfo(recommendRestaurantId)
+    }
+}

--- a/domain/src/main/java/org/gdsc/domain/usecase/PutRestaurantInfoUseCase.kt
+++ b/domain/src/main/java/org/gdsc/domain/usecase/PutRestaurantInfoUseCase.kt
@@ -1,0 +1,13 @@
+package org.gdsc.domain.usecase
+
+import org.gdsc.domain.model.request.ModifyRestaurantInfoRequest
+import org.gdsc.domain.repository.RestaurantRepository
+import javax.inject.Inject
+
+class PutRestaurantInfoUseCase @Inject constructor(
+    private val restaurantRepository: RestaurantRepository
+){
+    suspend operator fun invoke(putRestaurantInfoRequest: ModifyRestaurantInfoRequest) {
+        restaurantRepository.putRestaurantInfo(putRestaurantInfoRequest)
+    }
+}

--- a/presentation/src/main/java/org/gdsc/presentation/view/MainActivity.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/MainActivity.kt
@@ -25,6 +25,7 @@ import org.gdsc.presentation.databinding.ActivityMainBinding
 import org.gdsc.presentation.utils.slideDown
 import org.gdsc.presentation.utils.slideUp
 import org.gdsc.presentation.utils.toPx
+import org.gdsc.presentation.view.home.HomeFragmentDirections
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity() {
@@ -180,6 +181,14 @@ class MainActivity : BaseActivity() {
 
     fun changeToolbarVisible(isVisible: Boolean) {
         binding.toolBar.isVisible = isVisible
+    }
+
+    fun navigateToEditRestaurantInfo(restaurantId: Int) {
+
+        val action = HomeFragmentDirections.actionHomeFragmentToRegisterRestaurantFragment(
+            targetRestaurantId = restaurantId
+        )
+        navController.navigate(action)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/presentation/src/main/java/org/gdsc/presentation/view/WebAppInterface.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/WebAppInterface.kt
@@ -5,11 +5,22 @@ import android.webkit.JavascriptInterface
 import android.widget.Toast
 
 /** Instantiate the interface and set the context  */
-class WebAppInterface(private val mContext: Context) {
+class WebAppInterface(
+    private val mContext: Context,
+    private val slideUpBottomNavigationView: () -> Unit = {},
+    private val slideDownBottomNavigationView: () -> Unit = {}
+) {
 
     /** Show a toast from the web page  */
     @JavascriptInterface
     fun showToast(toast: String) {
         Toast.makeText(mContext, toast, Toast.LENGTH_SHORT).show()
     }
+
+    @JavascriptInterface
+    fun setVisibleNavigationAndToolBar(isVisible: Boolean) {
+        if (isVisible) slideUpBottomNavigationView()
+        else slideDownBottomNavigationView()
+    }
+
 }

--- a/presentation/src/main/java/org/gdsc/presentation/view/WebAppInterface.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/WebAppInterface.kt
@@ -8,7 +8,8 @@ import android.widget.Toast
 class WebAppInterface(
     private val mContext: Context,
     private val slideUpBottomNavigationView: () -> Unit = {},
-    private val slideDownBottomNavigationView: () -> Unit = {}
+    private val slideDownBottomNavigationView: () -> Unit = {},
+    private val navigateToRestaurantEdit: (Int) -> Unit = {}
 ) {
 
     /** Show a toast from the web page  */
@@ -21,6 +22,11 @@ class WebAppInterface(
     fun setVisibleNavigationAndToolBar(isVisible: Boolean) {
         if (isVisible) slideUpBottomNavigationView()
         else slideDownBottomNavigationView()
+    }
+
+    @JavascriptInterface
+    fun editRestaurantInfo(restaurantId: Int) {
+        navigateToRestaurantEdit(restaurantId)
     }
 
 }

--- a/presentation/src/main/java/org/gdsc/presentation/view/WebAppInterface.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/WebAppInterface.kt
@@ -19,7 +19,7 @@ class WebAppInterface(
     }
 
     @JavascriptInterface
-    fun setVisibleNavigationAndToolBar(isVisible: Boolean) {
+    fun navigationEnable(isVisible: Boolean) {
         if (isVisible) slideUpBottomNavigationView()
         else slideDownBottomNavigationView()
     }

--- a/presentation/src/main/java/org/gdsc/presentation/view/home/HomeFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/home/HomeFragment.kt
@@ -9,6 +9,8 @@ import android.view.ViewGroup
 import android.webkit.WebViewClient
 import dagger.hilt.android.AndroidEntryPoint
 import org.gdsc.presentation.databinding.FragmentHomeBinding
+import org.gdsc.presentation.view.MainActivity
+import org.gdsc.presentation.view.WebAppInterface
 
 @AndroidEntryPoint
 class HomeFragment : Fragment() {
@@ -28,11 +30,24 @@ class HomeFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val parentActivity = requireActivity() as MainActivity
+
         binding.webView.apply {
             loadUrl("https://jmt-matzip.dev")
             settings.javaScriptEnabled = true
             webViewClient = WebViewClient()
+
+            addJavascriptInterface(WebAppInterface(
+                requireContext(),
+                {
+                    parentActivity.slideUpBottomNavigationView()
+                },
+                {
+                    parentActivity.slideDownBottomNavigationView()
+                }
+            ), "Android")
         }
+
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/java/org/gdsc/presentation/view/home/HomeFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/home/HomeFragment.kt
@@ -44,6 +44,9 @@ class HomeFragment : Fragment() {
                 },
                 {
                     parentActivity.slideDownBottomNavigationView()
+                },
+                {
+                    parentActivity.navigateToEditRestaurantInfo(it)
                 }
             ), "Android")
         }

--- a/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/RegisterRestaurantFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/RegisterRestaurantFragment.kt
@@ -2,13 +2,10 @@ package org.gdsc.presentation.view.restaurantregistration
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.KeyEvent
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.net.toUri
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
@@ -32,7 +29,6 @@ import org.gdsc.presentation.utils.repeatWhenUiStarted
 import org.gdsc.presentation.utils.animateShrinkWidth
 import org.gdsc.presentation.utils.checkMediaPermissions
 import org.gdsc.presentation.utils.findPath
-import org.gdsc.presentation.utils.showMediaPermissionsDialog
 import org.gdsc.presentation.view.MainActivity
 import org.gdsc.presentation.view.WebViewActivity
 import org.gdsc.presentation.view.custom.FoodCategoryBottomSheetDialog
@@ -79,18 +75,38 @@ class RegisterRestaurantFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initInfo()
         observeStates()
         setFoodCategoryContainer()
         setDrinkPossibilityCheckbox()
         setIntroductionEditText()
-        setAddImageButton()
-        setImageList()
-        setRecommendDrinkEditText()
         setRecommendMenuEditText()
-        setToolbarTitle()
-
+        setRecommendDrinkEditText()
         setAdapter()
+
+        // register
+        if (navArgs.targetRestaurantId == -1) {
+            initInfo()
+            setToolbarTitle(navArgs.restaurantLocationInfo?.placeName ?: String.Empty)
+            setAddImageButton()
+            setImageList()
+
+            // modify
+        } else {
+            viewModel.getRestaurantInfo(navArgs.targetRestaurantId) {
+                setToolbarTitle(it.name)
+                binding.introductionEditText.setText(it.introduce)
+                binding.recommendDrinkEditText.editText.setText(it.goWellWithLiquor)
+                it.recommendMenu.split('#').drop(1).forEach { menu ->
+                    binding.recommendMenuChipGroup.addView(
+                        Chip(requireContext()).apply {
+                            text = menu
+                        }
+                    )
+                }
+
+            }
+        }
+
 
     }
 
@@ -116,7 +132,7 @@ class RegisterRestaurantFragment : BaseFragment() {
 
     // nullable한 타입이 있다면 핸들링 처리 해주기
     private fun initInfo() {
-        navArgs.restaurantLocationInfo.let {
+        navArgs.restaurantLocationInfo?.let {
             viewModel.setRestaurantLocationIno(it)
         }
         navArgs.restaurantDetailInfo?.let {
@@ -161,36 +177,57 @@ class RegisterRestaurantFragment : BaseFragment() {
                 binding.selectImageCountText.text =
                     getString(
                         R.string.text_counter_max_ten,
-                        viewModel.isFoodImagesListState.value.size ?: 0
+                        viewModel.isFoodImagesListState.value.size
                     )
 
                 adapter.submitList(list)
 
-                binding.registerButton.setOnClickListener {
+                binding.registerButton.apply {
 
-                    val pictures = mutableListOf<MultipartBody.Part>()
+                    if (navArgs.targetRestaurantId == -1) this.text = "등록하기"
+                    else this.text = "수정하기"
 
-                    list.forEach {
+                    setOnClickListener {
 
-                        val file = File(it.toUri().findPath(requireContext()))
+                    if (navArgs.targetRestaurantId == -1) {
+                        val pictures = mutableListOf<MultipartBody.Part>()
 
-                        val requestFile = RequestBody.create(MediaType.parse("image/png"), file)
-                        val body =
-                            MultipartBody.Part.createFormData("pictures", file.name, requestFile)
+                        list.forEach {
 
-                        pictures.add(body)
+                            val file = File(it.toUri().findPath(requireContext()))
 
-                    }
+                            val requestFile = RequestBody.create(MediaType.parse("image/png"), file)
+                            val body =
+                                MultipartBody.Part.createFormData(
+                                    "pictures",
+                                    file.name,
+                                    requestFile
+                                )
 
-                    lifecycleScope.launch(Dispatchers.IO) {
-                        viewModel.registerRestaurant(pictures, navArgs.restaurantLocationInfo) { restaurantId ->
+                            pictures.add(body)
 
-                            val intent = Intent(requireContext(), WebViewActivity::class.java)
-                            // 주소는 변경 되어야 함, 현재는 Lucy LocalHost 테스트
-                            intent.putExtra("url", "http://172.20.10.13:3000/detail/$restaurantId")
-                            startActivity(intent)
                         }
+
+                        lifecycleScope.launch(Dispatchers.IO) {
+                            viewModel.registerRestaurant(
+                                pictures,
+                                navArgs.restaurantLocationInfo ?: throw Exception()
+                            ) { restaurantId ->
+
+                                val intent = Intent(requireContext(), WebViewActivity::class.java)
+                                // 주소는 변경 되어야 함, 현재는 Lucy LocalHost 테스트
+                                intent.putExtra(
+                                    "url",
+                                    "http://172.20.10.13:3000/detail/$restaurantId"
+                                )
+                                startActivity(intent)
+                            }
+                        }
+                    } else {
+                        viewModel.modifyRestaurantInfo(navArgs.targetRestaurantId)
                     }
+
+                }
                 }
             }
         }
@@ -266,10 +303,8 @@ class RegisterRestaurantFragment : BaseFragment() {
             LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
     }
 
-    private fun setToolbarTitle() {
-        (requireActivity() as MainActivity).changeToolbarTitle(
-            navArgs.restaurantLocationInfo.placeName
-        )
+    private fun setToolbarTitle(restaurantName: String) {
+        (requireActivity() as MainActivity).changeToolbarTitle(restaurantName)
     }
 
     override fun onDestroyView() {

--- a/presentation/src/main/res/navigation/main_nav_graph.xml
+++ b/presentation/src/main/res/navigation/main_nav_graph.xml
@@ -9,7 +9,11 @@
         android:id="@+id/home_fragment"
         android:name="org.gdsc.presentation.view.home.HomeFragment"
         android:label="home_fragment"
-        tools:layout="@layout/fragment_home" />
+        tools:layout="@layout/fragment_home" >
+        <action
+            android:id="@+id/action_home_fragment_to_registerRestaurant_fragment"
+            app:destination="@id/registerRestaurant_fragment" />
+    </fragment>
     <fragment
         android:id="@+id/my_page_fragment"
         android:name="org.gdsc.presentation.view.mypage.MyPageFragment"
@@ -52,7 +56,9 @@
 
         <argument
             android:name="restaurantLocationInfo"
-            app:argType="org.gdsc.domain.model.RestaurantLocationInfo" />
+            app:argType="org.gdsc.domain.model.RestaurantLocationInfo"
+            app:nullable="true"
+            android:defaultValue="@null"/>
 
         <argument
             android:name="restaurantDetailInfo"
@@ -65,6 +71,12 @@
             app:argType="string[]"
             app:nullable="true"
             android:defaultValue="@null"/>
+
+        <argument
+            android:name="targetRestaurantId"
+            app:argType="integer"
+            android:defaultValue="-1"/>
+
         <action
             android:id="@+id/action_registerRestaurantFragment_to_multiImagePickerFragment"
             app:destination="@id/multiImagePicker_fragment"/>
@@ -112,7 +124,7 @@
     <fragment
         android:id="@+id/ImagePickerFragment"
         android:name="org.gdsc.presentation.login.ImagePickerFragment"
-        label="fragment_image_picker"
+        android:label="fragment_image_picker"
         tools:layout="@layout/fragment_image_picker" >
     </fragment>
 


### PR DESCRIPTION
## 
- 맛집 수정 기능 구현
  - 맛집 등록 페이지를 재활용
    - NavArg로 전달되는 targetRestaurantId 값으로 등록 페이지인지, 수정 페이지인지 판다
- WebAppbinterface에 기능 추가 및 설정
  - 바텀 네비게이션 바 조절(slide up/down) 기능 추가
  - 맛집 수정 페이지로 이동 기능 추가