### PR TITLE
[fix/google_login]: 계정 없을 때 one tap Exception 수정

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="org.gdsc.presentation">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     package="org.gdsc.presentation">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/presentation/src/main/java/org/gdsc/presentation/login/LoginFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/login/LoginFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -23,7 +22,6 @@ import kotlinx.coroutines.launch
 import org.gdsc.domain.model.response.UserLoginAction
 import org.gdsc.presentation.R
 import org.gdsc.presentation.databinding.FragmentLoginBinding
-import org.gdsc.presentation.utils.repeatWhenUiStarted
 import org.gdsc.presentation.view.LoginManager
 import org.gdsc.presentation.view.MainActivity
 
@@ -78,9 +76,7 @@ class LoginFragment : Fragment() {
     }
 
     private fun showGoogleAccountRegistrationPrompt() {
-        (context as Activity).runOnUiThread {
-            Toast.makeText(requireContext(), "구글 계정을 등록해주세요.", Toast.LENGTH_SHORT).show()
-        }
+        Toast.makeText(requireContext(), "구글 계정을 등록해주세요.", Toast.LENGTH_SHORT).show()
 
         val intent = Intent(Settings.ACTION_ADD_ACCOUNT)
         intent.putExtra(Settings.EXTRA_ACCOUNT_TYPES, arrayOf("com.google"))


### PR DESCRIPTION
AccountManager로 getAccounts하면 API 23이후로 계정 정보를 넘겨주지 않는 문제가 발생했습니다. 그래서 One Tap 동작에서 발생하는 Exception을 try catch로 잡아서 이후 계정 등록 하도록 넘겼습니다.