### PR TITLE
맛집 등록 화면에서 확인 화면으로 넘어갔다가 돌아오면 일시적으로 초기 StatusContainer가 설정되는 이슈 해결

### DIFF
--- a/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/SearchRestaurantLocationInfoFragment.kt
+++ b/presentation/src/main/java/org/gdsc/presentation/view/restaurantregistration/SearchRestaurantLocationInfoFragment.kt
@@ -111,6 +111,17 @@ class SearchRestaurantLocationInfoFragment : Fragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (adapter.currentList.isEmpty()) {
+            setVisibleStatusContainer(true)
+            setStatusImage(R.drawable.jmt_wink_character)
+            setStatusContainerText(getString(R.string.search_for_recommendable_restaurant))
+        } else {
+            setVisibleStatusContainer(false)
+        }
+    }
+
     private fun setAdapter() {
         binding.restaurantInfoRecyclerView.adapter = adapter
         binding.restaurantInfoRecyclerView.layoutManager = LinearLayoutManager(requireContext())

--- a/presentation/src/main/res/layout/fragment_search_restaurant_location_info.xml
+++ b/presentation/src/main/res/layout/fragment_search_restaurant_location_info.xml
@@ -37,7 +37,6 @@
             android:id="@+id/status_image"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/jmt_wink_character"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -47,7 +46,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:text="@string/search_for_recommendable_restaurant"
             android:textAlignment="center"
             android:textAppearance="@style/text_large_bold"
             android:textColor="@color/grey300"


### PR DESCRIPTION
## 개요
- 맛집 등록 화면에서 확인 화면으로 넘어갔다가 돌아오면 검색결과가 남아있음에도 불구하고 검색을 해달라는 문구와 아이콘이 일시적으로 나타났던 문제 해결